### PR TITLE
Revert "Utility updates capi fixes"

### DIFF
--- a/AudioManagerUtilities/include/CAmCommonAPIWrapper.h
+++ b/AudioManagerUtilities/include/CAmCommonAPIWrapper.h
@@ -22,7 +22,6 @@
 #include <string>
 #include <list>
 #include <map>
-#include <unordered_map>
 #include <queue>
 #include <memory>
 #include <cassert>
@@ -49,37 +48,29 @@ class CAmSocketHandler;
 
 class CAmCommonAPIWrapper
 {
-    void commonPrepareCallback ( const sh_pollHandle_t, void* );
+    void commonPrepareCallback(const sh_pollHandle_t handle, void* userData);
 	TAmShPollPrepare<CAmCommonAPIWrapper> pCommonPrepareCallback;
+
+    bool commonDispatchCallback(const sh_pollHandle_t handle, void* userData);
+    TAmShPollDispatch<CAmCommonAPIWrapper> pCommonDispatchCallback;
 
     void commonFireCallback(const pollfd pollfd, const sh_pollHandle_t, void*);
     TAmShPollFired<CAmCommonAPIWrapper> pCommonFireCallback;
 
     bool commonCheckCallback(const sh_pollHandle_t handle, void*);
     TAmShPollCheck<CAmCommonAPIWrapper> pCommonCheckCallback;
-    
-    bool commonDispatchCallback(const sh_pollHandle_t handle, void* userData);
-    TAmShPollDispatch<CAmCommonAPIWrapper> pCommonDispatchCallback;
 
     void commonTimerCallback(sh_timerHandle_t handle, void* userData);
     TAmShTimerCallBack<CAmCommonAPIWrapper> pCommonTimerCallback;
 
+     struct timerHandles
+    {
+        sh_timerHandle_t handle;
+        CommonAPI::Timeout* timeout;
+    };
+
     CAmSocketHandler *mpSocketHandler; //!< pointer to the sockethandler
 
-    typedef std::vector<CommonAPI::DispatchSource*> ArrayDispatchSources;
-    typedef ArrayDispatchSources::iterator IteratorArrayDispatchSources;
-    typedef std::unordered_map<am::sh_pollHandle_t, CommonAPI::Watch*> MapWatches;
-    typedef MapWatches::iterator IteratorMapWatches;
-    typedef std::unordered_map<am::sh_pollHandle_t,std::list<CommonAPI::DispatchSource*>> MapDispatchSources;
-    typedef MapDispatchSources::iterator IteratorDispatchSources;
-    typedef std::unordered_map<am::sh_pollHandle_t, CommonAPI::Timeout*> MapTimeouts;
-    typedef MapTimeouts::iterator IteratorMapTimeouts;
-    
-    ArrayDispatchSources mRegisteredDispatchSources;
-    MapWatches mMapWatches;
-    MapDispatchSources mSourcesToDispatch;
-    MapTimeouts mListTimerhandles;
-    
     std::shared_ptr<CommonAPI::Runtime> mRuntime;
     std::shared_ptr<CommonAPI::MainLoopContext> mContext;
 
@@ -87,23 +78,22 @@ class CAmCommonAPIWrapper
     CommonAPI::WatchListenerSubscription mWatchListenerSubscription;
     CommonAPI::TimeoutSourceListenerSubscription mTimeoutSourceListenerSubscription;
     CommonAPI::WakeupListenerSubscription mWakeupListenerSubscription;
-
+    std::multimap<CommonAPI::DispatchPriority, CommonAPI::DispatchSource*> mRegisteredDispatchSources;
+    std::map<int,CommonAPI::Watch*> mMapWatches;
+    CommonAPI::Watch* mWatchToCheck;
+    std::list<CommonAPI::DispatchSource*> mSourcesToDispatch;
+    std::vector<timerHandles> mpListTimerhandles;
 
 	void registerDispatchSource(CommonAPI::DispatchSource* dispatchSource, const CommonAPI::DispatchPriority dispatchPriority);
 	void deregisterDispatchSource(CommonAPI::DispatchSource* dispatchSource);
-    void deregisterAllDispatchSource();
 	void registerWatch(CommonAPI::Watch* watch, const CommonAPI::DispatchPriority dispatchPriority);
 	void deregisterWatch(CommonAPI::Watch* watch);
-    void deregisterAllWatches();
 	void registerTimeout(CommonAPI::Timeout* timeout, const CommonAPI::DispatchPriority dispatchPriority);
 	void deregisterTimeout(CommonAPI::Timeout* timeout);
-    void deregisterAllTimeouts();
-
-    CommonAPI::Watch* watchWithHandle(const sh_pollHandle_t handle);
-    CommonAPI::Timeout* timeoutWithHandle(const sh_pollHandle_t handle);
+	void wakeup();
 
 protected:
-    CAmCommonAPIWrapper(CAmSocketHandler* socketHandler, const std::string& applicationName = "") ;
+    CAmCommonAPIWrapper(CAmSocketHandler* socketHandler, const std::string & applicationName = "") ;
 
 public:
 
@@ -143,25 +133,24 @@ public:
 	* @return Pointer to the socket handler.
 	*/
 	CAmSocketHandler *getSocketHandler() const { return mpSocketHandler; }
-
-    /** 
-    * \brief Deprecated method. This class is used only in single connection applications and no connectionId is needed. Instead you should use bool registerService(const std::shared_ptr<TStubImp> & shStub, const std::string & domain, const std::string & instance). 
-    * 
-    * 
-    * Example: std::shared_ptr<ConcreteStubClass> aStub; 
-    *        registerService(  aStub, "local", "com.your_company.instance_name", "service-name"); 
-    * 
-    * @param shStub: Shared pointer to a stub instance 
-    * @param domain: A string with the domain name, usually "local" 
-    * @param instance: Common-api instance string as example "com.your_company.instance_name" 
-    * @param connectionId: A string connection id, which is used by CommonAPI to group applications 
-    * 
-    */ 
-    template <class TStubImp> bool __attribute__((deprecated)) registerService(const std::shared_ptr<TStubImp> & shStub, const std::string & domain, const std::string & instance, const CommonAPI::ConnectionId_t __attribute__((__unused__)) & /*connectionId*/) 
-    { 
-        return mRuntime->registerService(domain, instance, shStub, mContext); 
-    } 
-	
+#if COMMONAPI_VERSION_NUMBER >= 300
+	/**
+	* \brief Register stub objects.
+	*
+	* Example: std::shared_ptr<ConcreteStubClass> aStub;
+	* 		   registerService(	aStub, "local", "com.your_company.instance_name", "service-name");
+	*
+	* @param shStub: Shared pointer to a stub instance
+	* @param domain: A string with the domain name, usually "local"
+	* @param instance: Common-api instance string as example "com.your_company.instance_name"
+	* @param connectionId: A string connection id, which is used by CommonAPI to group applications
+	*
+	*/
+	template <class TStubImp> bool registerService(const std::shared_ptr<TStubImp> & shStub, const std::string & domain, const std::string & instance, const CommonAPI::ConnectionId_t & connectionId)
+	{
+		return mRuntime->registerService(domain, instance, shStub, connectionId);
+	}
+#endif
 	/**
 	* \brief Register stub objects.
 	*
@@ -191,93 +180,96 @@ public:
 		return mRuntime->unregisterService(domain, interface, instance);
 	}
 
-    /**
-    * \brief Deprecated method. Instead you should use bool registerService(const std::shared_ptr<TStubImp> & shStub, const std::string & domain, const std::string & instance). 
-    * 
-    * Register stub objects. 
-    * 
-    * Example: std::shared_ptr<ConcreteStubClass> aStub; 
-    *        registerService(  aStub, "local:com.your_company.interface_name:com.your_company.instance_name"); 
-    * 
-    * @param shStub: Shared pointer to a stub instance 
-    * @param address: Complete common-api address as example "local:com.your_company.interface_name:com.your_company.instance_name" 
-    * 
-    */ 
-    template <class TStubImp> bool __attribute__((deprecated)) registerStub(const std::shared_ptr<TStubImp> & shStub, const std::string & address) 
-    { 
-        std::vector<std::string> parts = CommonAPI::split(address, ':'); 
-        assert(parts.size()==3); 
+	/**
+	* \brief Deprecated method. Instead you should use bool registerService(const std::shared_ptr<TStubImp> & shStub, const std::string & domain, const std::string & instance).
+	*
+	* Register stub objects.
+	*
+	* Example: std::shared_ptr<ConcreteStubClass> aStub;
+	* 		   registerService(	aStub, "local:com.your_company.interface_name:com.your_company.instance_name");
+	*
+	* @param shStub: Shared pointer to a stub instance
+	* @param address: Complete common-api address as example "local:com.your_company.interface_name:com.your_company.instance_name"
+	*
+	*/
+	template <class TStubImp> bool __attribute__((deprecated)) registerStub(const std::shared_ptr<TStubImp> & shStub, const std::string & address)
+ 	{
+		std::vector<std::string> parts = CommonAPI::split(address, ':');
+		assert(parts.size()==3);
 
-        return registerService(shStub, parts[0], parts[2]); 
-    }
+		return registerService(shStub, parts[0], parts[2]);
+ 	}
 
-    /** 
-    * \brief Deprecated method. Instead you should use bool unregisterService(const std::string &domain, const std::string &interface, const std::string &instance). 
-    * 
-    * Unregister stub objects. 
-    * 
-    * @param address: Complete common-api address as example "local:com.your_company.interface_name:com.your_company.instance_name" 
-    * 
-    */ 
-    bool __attribute__((deprecated)) unregisterStub(const std::string & address) 
-    {
-        std::vector<std::string> parts = CommonAPI::split(address, ':'); 
-        assert(parts.size()==3); 
+	/**
+	* \brief Deprecated method. Instead you should use bool unregisterService(const std::string &domain, const std::string &interface, const std::string &instance).
+	*
+	* Unregister stub objects.
+	*
+	* @param address: Complete common-api address as example "local:com.your_company.interface_name:com.your_company.instance_name"
+	*
+	*/
+	bool __attribute__((deprecated)) unregisterStub(const std::string & address)
+	{
+		std::vector<std::string> parts = CommonAPI::split(address, ':');
+		assert(parts.size()==3);
 
-        return unregisterService(parts[0], parts[1], parts[2]); 
-    }
+		return unregisterService(parts[0], parts[1], parts[2]);
+ 	}
 
-    /** 
-    * \brief  Deprecated method. This class is used only in single connection applications and no connectionId is needed. Instead you should use buildProxy(const std::string &domain, const std::string &instance). 
-    * 
-    * Example: std::shared_ptr<AProxyClass<>> aProxy = buildProxy<AProxyClass>("local", "com.your_company.instance_name", "client-name"); 
-    * 
-    * @param domain: A string with the domain name, usually "local" 
-    * @param instance: Common-api instance string as example "com.your_company.instance_name" 
-    * @param connectionId: A string connection id, which is used by CommonAPI to group applications 
-    * 
-    * @return A proxy object. 
-    */ 
-    template<template<typename ...> class ProxyClass, typename ... AttributeExtensions> 
-    std::shared_ptr<ProxyClass<AttributeExtensions...>> __attribute__((deprecated)) buildProxy(const std::string &domain, const std::string &instance, const CommonAPI::ConnectionId_t __attribute__((__unused__)) & /*connectionId*/) 
-    { 
-        return mRuntime->buildProxy<ProxyClass>(domain, instance, mContext);
-    } 
- 
-    /** 
-    * \brief Build proxy objects.
-    *
-    * Example: std::shared_ptr<AProxyClass<>> aProxy = buildProxy<AProxyClass>("local", "com.your_company.instance_name");
-    *
-    * @param domain: A string with the domain name, usually "local"
-    * @param instance: Common-api instance string as example "com.your_company.instance_name"
-    *
-    * @return A proxy object.
-    */
+#if COMMONAPI_VERSION_NUMBER >= 300
+	/**
+	* \brief Build proxy objects.
+	*
+	* Example: std::shared_ptr<AProxyClass<>> aProxy = buildProxy<AProxyClass>("local", "com.your_company.instance_name", "client-name");
+	*
+	* @param domain: A string with the domain name, usually "local"
+	* @param instance: Common-api instance string as example "com.your_company.instance_name"
+	* @param connectionId: A string connection id, which is used by CommonAPI to group applications
+	*
+	* @return A proxy object.
+	*/
+	template<template<typename ...> class ProxyClass, typename ... AttributeExtensions>
+	std::shared_ptr<ProxyClass<AttributeExtensions...>> buildProxy(const std::string &domain, const std::string &instance, const CommonAPI::ConnectionId_t & connectionId)
+	{
+		return mRuntime->buildProxy<ProxyClass>(domain, instance, connectionId);
+	}
+#endif
+
+	/**
+	* \brief Build proxy objects.
+	*
+	* Example: std::shared_ptr<AProxyClass<>> aProxy = buildProxy<AProxyClass>("local", "com.your_company.instance_name");
+	*
+	* @param domain: A string with the domain name, usually "local"
+	* @param instance: Common-api instance string as example "com.your_company.instance_name"
+	*
+	* @return A proxy object.
+	*/
 	template<template<typename ...> class ProxyClass, typename ... AttributeExtensions>
 	std::shared_ptr<ProxyClass<AttributeExtensions...>> buildProxy(const std::string &domain, const std::string &instance)
 	{
 		return mRuntime->buildProxy<ProxyClass>(domain, instance, mContext);
 	}
 
-    /** 
-    * \brief  Deprecated method. Instead you should use buildProxy(const std::string &domain, const std::string &instance). 
-    * 
-    * Build proxy objects. 
-    * Example: std::shared_ptr<AProxyClass<>> aProxy = buildProxy<AProxyClass>("local:com.your_company.interface_name:com.your_company.instance_name"); 
-    * 
-    * @param address: Complete common-api address as example "local:com.your_company.interface_name:com.your_company.instance_name" 
-    * 
-    * @return A proxy object. 
-    */ 
-    template<template<typename ...> class ProxyClass, typename ... AttributeExtensions> 
-    std::shared_ptr<ProxyClass<AttributeExtensions...>> __attribute__((deprecated)) buildProxy(const std::string & address) 
-    { 
-        std::vector<std::string> parts=CommonAPI::split(address, ':'); 
-        assert(parts.size()==3); 
-    
-        return buildProxy<ProxyClass>(parts[0], parts[2]); 
-    }
+
+	/**
+	* \brief  Deprecated method. Instead you should use buildProxy(const std::string &domain, const std::string &instance).
+	*
+	* Build proxy objects.
+	* Example: std::shared_ptr<AProxyClass<>> aProxy = buildProxy<AProxyClass>("local:com.your_company.interface_name:com.your_company.instance_name");
+	*
+	* @param address: Complete common-api address as example "local:com.your_company.interface_name:com.your_company.instance_name"
+	*
+	* @return A proxy object.
+	*/
+	template<template<typename ...> class ProxyClass, typename ... AttributeExtensions>
+	std::shared_ptr<ProxyClass<AttributeExtensions...>> __attribute__((deprecated)) buildProxy(const std::string & address)
+	{
+		std::vector<std::string> parts=CommonAPI::split(address, ':');
+		assert(parts.size()==3);
+
+		return buildProxy<ProxyClass>(parts[0], parts[2]);
+	}
 
 };
 

--- a/AudioManagerUtilities/src/CAmCommonAPIWrapper.cpp
+++ b/AudioManagerUtilities/src/CAmCommonAPIWrapper.cpp
@@ -36,47 +36,21 @@ namespace am
 static CAmCommonAPIWrapper* pSingleCommonAPIInstance = NULL;
 
 
-bool timeoutToTimespec(const int64_t & localTimeout, timespec & pollTimeout)
-{    
-    if(CommonAPI::TIMEOUT_INFINITE == localTimeout)//dispatch never
-    {
-        return false;
-    }
-    else
-    {
-        if(CommonAPI::TIMEOUT_NONE==localTimeout)//dispatch immediately
-        {
-            pollTimeout.tv_sec = 0;
-            pollTimeout.tv_nsec = 5000000;//5 ms
-        }
-        else
-        {
-            pollTimeout.tv_sec = localTimeout / 1000;
-            pollTimeout.tv_nsec = (localTimeout % 1000) * 1000000;
-        }
-        return true;
-    }
-}
-
-
 CAmCommonAPIWrapper::CAmCommonAPIWrapper(CAmSocketHandler* socketHandler, const std::string & applicationName):
 				pCommonPrepareCallback(this,&CAmCommonAPIWrapper::commonPrepareCallback), //
+		        pCommonDispatchCallback(this, &CAmCommonAPIWrapper::commonDispatchCallback), //
 		        pCommonFireCallback(this, &CAmCommonAPIWrapper::commonFireCallback), //
 		        pCommonCheckCallback(this, &CAmCommonAPIWrapper::commonCheckCallback), //
-                pCommonDispatchCallback(this, &CAmCommonAPIWrapper::commonDispatchCallback), //
 		        pCommonTimerCallback(this, &CAmCommonAPIWrapper::commonTimerCallback), //
-                mpSocketHandler(socketHandler),
-                mRegisteredDispatchSources(),
-                mMapWatches(),
-                mSourcesToDispatch(),
-                mListTimerhandles()
+		        mpSocketHandler(socketHandler), //
+		        mWatchToCheck(NULL)
 {
 	assert(NULL!=socketHandler);
 //Get the runtime
 	mRuntime = CommonAPI::Runtime::get();
 	assert(NULL!=mRuntime);
 
-//Create the context
+	//Create the context
 	if(applicationName.size())
 		mContext = std::make_shared<CommonAPI::MainLoopContext>(applicationName);
 	else
@@ -101,11 +75,9 @@ CAmCommonAPIWrapper::~CAmCommonAPIWrapper()
 	mContext->unsubscribeForDispatchSources(mDispatchSourceListenerSubscription);
 	mContext->unsubscribeForWatches(mWatchListenerSubscription);
 	mContext->unsubscribeForTimeouts(mTimeoutSourceListenerSubscription);
-    deregisterAllDispatchSource();
-    deregisterAllTimeouts();
-    deregisterAllWatches();
 	mContext.reset();
 	mpSocketHandler = NULL;
+	mWatchToCheck = NULL;
 }
 
 CAmCommonAPIWrapper* CAmCommonAPIWrapper::instantiateOnce(CAmSocketHandler* socketHandler, const std::string & applicationName)
@@ -143,105 +115,123 @@ CAmCommonAPIWrapper* CAmCommonAPIWrapper::getInstance()
 	return pSingleCommonAPIInstance;
 }
 
+bool CAmCommonAPIWrapper::commonDispatchCallback(const sh_pollHandle_t handle, void *userData)
+{
+    (void) handle;
+    (void) userData;
+
+    std::list<CommonAPI::DispatchSource*>::iterator iterator(mSourcesToDispatch.begin());
+    for(;iterator!=mSourcesToDispatch.end();)
+    {
+    	CommonAPI::DispatchSource* source = *iterator;
+        if (!source->dispatch()) {
+            iterator=mSourcesToDispatch.erase(iterator);
+        }
+        else
+            iterator++;
+    }
+    if (!mSourcesToDispatch.empty())
+        return (true);
+
+    return false;
+}
+
+bool CAmCommonAPIWrapper::commonCheckCallback(const sh_pollHandle_t, void *)
+{
+    std::vector<CommonAPI::DispatchSource*> vecDispatch=mWatchToCheck->getDependentDispatchSources();
+    mSourcesToDispatch.insert(mSourcesToDispatch.end(), vecDispatch.begin(), vecDispatch.end());
+
+    return (mWatchToCheck || !mSourcesToDispatch.empty());
+}
+
+void CAmCommonAPIWrapper::commonFireCallback(const pollfd pollfd, const sh_pollHandle_t, void *)
+{
+    mWatchToCheck=NULL;
+    try
+    {
+        mWatchToCheck=mMapWatches.at(pollfd.fd);
+    }
+    catch (const std::out_of_range& error) {
+      logInfo(__PRETTY_FUNCTION__,error.what());
+      return;
+    }
+
+    mWatchToCheck->dispatch(pollfd.events);
+}
+
 void CAmCommonAPIWrapper::commonPrepareCallback(const sh_pollHandle_t, void*)
 {
     for (auto dispatchSourceIterator = mRegisteredDispatchSources.begin();
-            dispatchSourceIterator != mRegisteredDispatchSources.end();
-            dispatchSourceIterator++)
+                            dispatchSourceIterator != mRegisteredDispatchSources.end();
+                            dispatchSourceIterator++)
     {
         int64_t dispatchTimeout(CommonAPI::TIMEOUT_INFINITE);
-        if((*dispatchSourceIterator)->prepare(dispatchTimeout))
+        if(dispatchSourceIterator->second->prepare(dispatchTimeout))
         {
-            while ((*dispatchSourceIterator)->dispatch());
+            while (dispatchSourceIterator->second->dispatch());
         }
     }
 }
 
-void CAmCommonAPIWrapper::commonFireCallback(const pollfd pollfd, const sh_pollHandle_t handle, void *)
+void CAmCommonAPIWrapper::registerDispatchSource(CommonAPI::DispatchSource* dispatchSource, const CommonAPI::DispatchPriority dispatchPriority)
 {
-    CommonAPI::Watch* pWatchToCheck = watchWithHandle(handle);
-    if( pWatchToCheck )   
-        pWatchToCheck->dispatch(pollfd.revents);
-}
-
-bool CAmCommonAPIWrapper::commonCheckCallback(const sh_pollHandle_t handle, void *)
-{
-    CommonAPI::Watch* pWatchToCheck = watchWithHandle(handle);
-    if( pWatchToCheck )
-    {
-        const ArrayDispatchSources & vecDispatch = pWatchToCheck->getDependentDispatchSources();
-        if(vecDispatch.size()>0)
-        {
-            mSourcesToDispatch[handle].insert(mSourcesToDispatch[handle].end(), vecDispatch.begin(), vecDispatch.end());
-            return true;
-        }
-    }
-    return false;
-}
-
-bool CAmCommonAPIWrapper::commonDispatchCallback(const sh_pollHandle_t handle, void *)
-{
-    CommonAPI::Watch* pWatchToCheck = watchWithHandle(handle);
-    if( pWatchToCheck )
-    {        
-        std::list<CommonAPI::DispatchSource*> & srcList = mSourcesToDispatch[handle];
-        for(auto it = srcList.begin();it!=srcList.end();)
-        {
-            if (false==(*it)->dispatch())
-                it=srcList.erase(it);
-            else
-                it++;
-        }
-        if (!srcList.empty())
-            return (true);
-    }
-    mSourcesToDispatch.erase(handle);
-    return false;
-}
-
-void CAmCommonAPIWrapper::commonTimerCallback(sh_timerHandle_t handle, void *)
-{
-    CommonAPI::Timeout* pTimeout = timeoutWithHandle(handle);
-    
-    if( NULL==pTimeout )
-    {
-        //erroneous call because deregisterTimeout has been called, so try to remove the timer from the sockethandler
-        mpSocketHandler->removeTimer(handle);
-    }
-    else
-    {
-        if ( false==pTimeout->dispatch() ) //it should be removed
-        {               
-            mpSocketHandler->removeTimer(handle);
-            mListTimerhandles.erase(handle);
-        }
-    #ifndef WITH_TIMERFD
-        else //the timeout should be rescheduled 
-            mpSocketHandler->restartTimer(handle);           
-    #endif        
-    }
-}
-
-void CAmCommonAPIWrapper::registerDispatchSource(CommonAPI::DispatchSource* dispatchSource, const CommonAPI::DispatchPriority)
-{
-    mRegisteredDispatchSources.push_back(dispatchSource);
+    mRegisteredDispatchSources.insert({dispatchPriority, dispatchSource});
 }
 
 void CAmCommonAPIWrapper::deregisterDispatchSource(CommonAPI::DispatchSource* dispatchSource)
 {
-    for(IteratorArrayDispatchSources dispatchSourceIterator = mRegisteredDispatchSources.begin(); dispatchSourceIterator != mRegisteredDispatchSources.end(); dispatchSourceIterator++) 
-    {
-        if( *dispatchSourceIterator == dispatchSource ) 
-        {
+    for(auto dispatchSourceIterator = mRegisteredDispatchSources.begin();
+            dispatchSourceIterator != mRegisteredDispatchSources.end();
+            dispatchSourceIterator++) {
+
+        if(dispatchSourceIterator->second == dispatchSource) {
             mRegisteredDispatchSources.erase(dispatchSourceIterator);
             break;
         }
     }
 }
 
-void CAmCommonAPIWrapper::deregisterAllDispatchSource()
+void CAmCommonAPIWrapper::deregisterWatch(CommonAPI::Watch* watch)
 {
-    mRegisteredDispatchSources.clear();
+    for(std::map<int,CommonAPI::Watch*>::iterator iter(mMapWatches.begin());iter!=mMapWatches.end();iter++)
+    {
+        if (iter->second == watch)
+        {
+            mMapWatches.erase(iter);
+            break;
+        }
+    }
+}
+
+void CAmCommonAPIWrapper::registerTimeout(CommonAPI::Timeout* timeout, const CommonAPI::DispatchPriority)
+{
+    timespec pollTimeout;
+    int64_t localTimeout = timeout->getTimeoutInterval();
+
+    pollTimeout.tv_sec = localTimeout / 1000;
+    pollTimeout.tv_nsec = (localTimeout % 1000) * 1000000;
+
+    //prepare handle and callback. new is eval, but there is no other choice because we need the pointer!
+    sh_timerHandle_t handle;
+
+    //add the timer to the pollLoop
+    mpSocketHandler->addTimer(pollTimeout, &pCommonTimerCallback, handle, timeout);
+
+    timerHandles myHandle({handle,timeout});
+    mpListTimerhandles.push_back(myHandle);
+
+    return;
+}
+
+void CAmCommonAPIWrapper::deregisterTimeout(CommonAPI::Timeout* timeout)
+{
+    for( std::vector<timerHandles>::iterator iter(mpListTimerhandles.begin());iter!=mpListTimerhandles.end();iter++)
+    {
+        if(iter->timeout==timeout)
+        {
+            mpSocketHandler->removeTimer(iter->handle);
+        }
+    }
 }
 
 void CAmCommonAPIWrapper::registerWatch(CommonAPI::Watch* watch, const CommonAPI::DispatchPriority)
@@ -253,103 +243,22 @@ void CAmCommonAPIWrapper::registerWatch(CommonAPI::Watch* watch, const CommonAPI
     am_Error_e error = mpSocketHandler->addFDPoll(pollfd_.fd, pollfd_.events, &pCommonPrepareCallback, &pCommonFireCallback, &pCommonCheckCallback, &pCommonDispatchCallback, watch, handle);
 
     //if everything is alright, add the watch and the handle to our map so we know this relationship
-    if (error != am_Error_e::E_OK || handle == 0)
-    {
+    if (error == !am_Error_e::E_OK || handle == 0)
         logError(__func__,"entering watch failed");
-    }
-    else
-        mMapWatches.insert(std::make_pair(handle,watch));
+
+    mMapWatches.insert(std::make_pair(pollfd_.fd,watch));
 }
 
-void CAmCommonAPIWrapper::deregisterWatch(CommonAPI::Watch* watch)
+void CAmCommonAPIWrapper::commonTimerCallback(sh_timerHandle_t handle, void *)
 {
-    for(IteratorMapWatches iter=mMapWatches.begin();iter!=mMapWatches.end();iter++)
+    for( std::vector<timerHandles>::iterator iter(mpListTimerhandles.begin());iter!=mpListTimerhandles.end();iter++)
     {
-        if (iter->second == watch)
+        if(iter->handle==handle)
         {
-            mpSocketHandler->removeFDPoll(iter->first);
-            mMapWatches.erase(iter);
-            break;
+            iter->timeout->dispatch();
         }
     }
 }
-
-void CAmCommonAPIWrapper::deregisterAllWatches()
-{
-    for(IteratorMapWatches iter=mMapWatches.begin();iter!=mMapWatches.end();iter++)
-        mpSocketHandler->removeFDPoll(iter->first);
-    mMapWatches.clear();
-}
-
-void CAmCommonAPIWrapper::registerTimeout(CommonAPI::Timeout* timeout, const CommonAPI::DispatchPriority)
-{
-    timespec pollTimeout;
-    if(timeoutToTimespec(timeout->getTimeoutInterval(), pollTimeout))
-    {
-        //prepare handle and callback. new is eval, but there is no other choice because we need the pointer!
-        sh_timerHandle_t handle;
-
-        //add the timer to the pollLoop
-        am_Error_e error = mpSocketHandler->addTimer(pollTimeout, &pCommonTimerCallback, handle, timeout, true);
-        if (error != am_Error_e::E_OK || handle == 0)
-        {
-            logError(__func__,"adding timer failed");
-        }
-        else
-        {
-            mListTimerhandles.insert(std::make_pair(handle,timeout));
-        }
-    }
-}
-
-void CAmCommonAPIWrapper::deregisterTimeout(CommonAPI::Timeout* timeout)
-{
-    for( IteratorMapTimeouts iter=mListTimerhandles.begin();iter!= mListTimerhandles.end();iter++)
-    {
-        if(iter->second==timeout)
-        {
-            mpSocketHandler->removeTimer(iter->first);
-            mListTimerhandles.erase(iter->first);
-            break;
-        }
-    }
-}
-
-void CAmCommonAPIWrapper::deregisterAllTimeouts()
-{
-    for( IteratorMapTimeouts iter=mListTimerhandles.begin();iter!= mListTimerhandles.end();iter++)
-        mpSocketHandler->removeTimer(iter->first);
-    mListTimerhandles.clear();
-}
-
-CommonAPI::Watch* CAmCommonAPIWrapper::watchWithHandle(const sh_pollHandle_t handle)
-{
-    CommonAPI::Watch* pWatchToCheck = NULL;
-    try
-    {
-        pWatchToCheck = mMapWatches.at(handle);        
-    }
-    catch (const std::out_of_range& error) 
-    {
-        logInfo(__PRETTY_FUNCTION__,error.what());
-    } 
-    return pWatchToCheck;
-}
-
-CommonAPI::Timeout* CAmCommonAPIWrapper::timeoutWithHandle(const sh_pollHandle_t handle)
-{
-    CommonAPI::Timeout* pTimeout = NULL;
-    try
-    {
-        pTimeout = mListTimerhandles.at(handle);        
-    }
-    catch (const std::out_of_range& error) 
-    {
-        logInfo(__PRETTY_FUNCTION__,error.what());
-    } 
-    return pTimeout;
-}
-
 
 CAmCommonAPIWrapper* (*getCAPI)()  = CAmCommonAPIWrapper::getInstance;
 

--- a/AudioManagerUtilities/src/CAmDltWrapper.cpp
+++ b/AudioManagerUtilities/src/CAmDltWrapper.cpp
@@ -23,14 +23,13 @@
  */
 
 
+#include "CAmDltWrapper.h"
 #include <string>
 #include <iostream>
 #include <string.h>
 #include <chrono>
 #include <ctime>
-#include <sys/types.h>
 #include <unistd.h>
-#include "CAmDltWrapper.h"
 
 namespace am
 {
@@ -626,7 +625,7 @@ bool CAmDltWrapper::initNoDlt(DltLogLevelType loglevel, DltContext* context)
 	bool CAmDltWrapper::init(DltLogLevelType loglevel, DltContext* context)
 	{
 		pthread_mutex_lock(&mMutex);
-		return initNoDlt(loglevel,context);
+		initNoDlt(loglevel,context);
 	}
 	
 	void CAmDltWrapper::send()

--- a/AudioManagerUtilities/src/CAmSocketHandler.cpp
+++ b/AudioManagerUtilities/src/CAmSocketHandler.cpp
@@ -31,7 +31,6 @@
 #include <features.h>
 #include <csignal>
 #include <unistd.h>
-#include <string.h>
 
 #include "CAmDltWrapper.h"
 #include "CAmSocketHandler.h"
@@ -43,38 +42,22 @@
 namespace am
 {
 
-#define CHECK_CALLER_THREAD_ID()\
-    if(std::this_thread::get_id() != mThreadID)\
-    {\
-        logError("Sockethandler: Call from another thread detected!");\
-        assert(false);\
-    }
-
-
-
-    
 CAmSocketHandler::CAmSocketHandler() :
         mPipe(), //
-        mDispatchDone(true), //
-        mSetPollKeys(MAX_POLLHANDLE), //
-        mListPoll(), //
-        mSetTimerKeys(MAX_TIMERHANDLE),
-        mListTimer(), //
-        #ifndef WITH_TIMERFD  
-        mListActiveTimer(), //
-        #else
-        mListRemovedTimers(),
-        #endif
-        mSetSignalhandlerKeys(MAX_POLLHANDLE), //
-        mSignalHandlers(), //
-        mRecreatePollfds(true),
-        mInternalCodes(internal_codes_e::NO_ERROR),
-        mSignalFdHandle(0),
-        mListActivePolls(),
-        mThreadID(std::this_thread::get_id())
-        #ifndef WITH_TIMERFD
-        ,mStartTime() //
-        #endif
+                mDispatchDone(true), //
+                mSetPollKeys(MAX_POLLHANDLE), //
+                mListPoll(), //
+                mSetTimerKeys(MAX_TIMERHANDLE),
+                mListTimer(), //
+                mListActiveTimer(), //
+                mSetSignalhandlerKeys(MAX_POLLHANDLE), //
+                mSignalHandlers(), //
+                mRecreatePollfds(true),
+                mInternalCodes(internal_codes_e::NO_ERROR),
+                mSignalFdHandle(0)
+#ifndef WITH_TIMERFD
+,mStartTime() //
+#endif
 {
     if (pipe(mPipe) == -1)
     {
@@ -86,17 +69,17 @@ CAmSocketHandler::CAmSocketHandler() :
     short event = 0;
     sh_pollHandle_t handle;
     event |= POLLIN;
-    if (addFDPoll(mPipe[0], event, NULL, [](const pollfd pollfd, const sh_pollHandle_t, void*)
-    {}, [](const sh_pollHandle_t, void*)
-    {   return (false);}, NULL, NULL, handle) != E_OK)
+    if (addFDPoll(mPipe[0], event, NULL,
+                [](const pollfd, const sh_pollHandle_t, void*){},
+                [](const sh_pollHandle_t, void*) { return (false); },
+            NULL, NULL, handle) != E_OK)
+    {
         mInternalCodes |= internal_codes_e::FD_ERROR;
+    }
 }
 
 CAmSocketHandler::~CAmSocketHandler()
 {
-#ifdef WITH_TIMERFD
-    closeRemovedTimers();
-#endif    
     for (auto it : mListPoll)
     {
         close(it.pollfdValue.fd);
@@ -114,16 +97,13 @@ void CAmSocketHandler::start_listenting()
     mDispatchDone = false;
     int16_t pollStatus;
 
-    CHECK_CALLER_THREAD_ID()
-    
 #ifndef WITH_TIMERFD 
     clock_gettime(CLOCK_MONOTONIC, &mStartTime);
 #endif    
     timespec buffertime;
     
-    std::list<sh_poll_s*> listPoll;
+    VectorListPoll_t cloneListPoll;
     VectorListPoll_t::iterator listmPollIt;
-    VectorListPollfd_t::iterator itMfdPollingArray;
     VectorListPollfd_t fdPollingArray; //!<the polling array for ppoll
     
     auto preparePollfd = [&](const sh_poll_s& row)
@@ -138,20 +118,17 @@ void CAmSocketHandler::start_listenting()
     {
         if (mRecreatePollfds)
         {
-#ifdef WITH_TIMERFD
-            closeRemovedTimers();
-#endif
             fdPollingArray.clear();
             //freeze mListPoll by copying it - otherwise we get problems when we want to manipulate it during the next lines
-            mListActivePolls = mListPoll;
+            cloneListPoll = mListPoll;
             //there was a change in the setup, so we need to recreate the fdarray from the list
-            std::for_each(mListActivePolls.begin(), mListActivePolls.end(), preparePollfd);
+            std::for_each(cloneListPoll.begin(), cloneListPoll.end(), preparePollfd);
             mRecreatePollfds = false;
         }
         else
         {
             //first we go through the registered filedescriptors and check if someone needs preparation:
-            std::for_each(mListActivePolls.begin(), mListActivePolls.end(), CAmSocketHandler::prepare);
+            std::for_each(cloneListPoll.begin(), cloneListPoll.end(), CAmSocketHandler::prepare);
         }
 
 #ifndef WITH_TIMERFD
@@ -175,25 +152,25 @@ void CAmSocketHandler::start_listenting()
 
         if (pollStatus != 0) //only check filedescriptors if there was a change
         {
+            std::list<sh_poll_s> listPoll;
             //todo: here could be a timer that makes sure naughty plugins return!
-            listPoll.clear();
             //stage 0+1, call firedCB
-            for (itMfdPollingArray = fdPollingArray.begin(); itMfdPollingArray != fdPollingArray.end(); ++itMfdPollingArray)
+            listmPollIt = cloneListPoll.begin();
+            for (auto it : fdPollingArray)
             {
-                itMfdPollingArray->revents &= itMfdPollingArray->events | POLLERR | POLLHUP;
-                if ( itMfdPollingArray->revents!=0 )
+                if (CAmSocketHandler::eventFired(it))
                 {
-                    listmPollIt = mListActivePolls.begin();
-                    std::advance(listmPollIt, std::distance(fdPollingArray.begin(), itMfdPollingArray));
-
-                    sh_poll_s & pollObj = *listmPollIt;
-
-                    listPoll.push_back(&pollObj);
-                    CAmSocketHandler::fire(&pollObj);
-                    itMfdPollingArray->revents = 0;
+                    listmPollIt->pollfdValue.revents = it.revents;
+                    listPoll.push_back(*listmPollIt);
+                    CAmSocketHandler::fire(*listmPollIt);
                 }
+                else
+                {
+                    listmPollIt->pollfdValue.revents = 0;
+                }
+                listmPollIt++;
             }
- 
+            
             //stage 2, lets ask around if some dispatching is necessary, the ones who need stay on the list
             listPoll.remove_if(CAmSocketHandler::noDispatching);
 
@@ -246,7 +223,7 @@ void CAmSocketHandler::exit_mainloop()
 
 bool CAmSocketHandler::fatalErrorOccurred() 
 { 
-    return ((mInternalCodes&internal_codes_e::PIPE_ERROR)>0)||((mInternalCodes&internal_codes_e::FD_ERROR)>0);
+    return ((mInternalCodes&internal_codes_e::PIPE_ERROR)>0)||((mInternalCodes&internal_codes_e::FD_ERROR)>0); 
 }
 
 am_Error_e CAmSocketHandler::getFDPollData(const sh_pollHandle_t handle, sh_poll_s & outPollData)
@@ -269,8 +246,6 @@ am_Error_e CAmSocketHandler::getFDPollData(const sh_pollHandle_t handle, sh_poll
   */
 am_Error_e CAmSocketHandler::listenToSignals(const std::vector<uint8_t> & listSignals)
 {
-    CHECK_CALLER_THREAD_ID()
-    
     int fdErr;
     uint8_t addedSignals = 0;
     sigset_t sigset;
@@ -312,19 +287,31 @@ am_Error_e CAmSocketHandler::listenToSignals(const std::vector<uint8_t> & listSi
         return (E_NOT_POSSIBLE);
     }
 
-    sh_poll_s sgPollData;
+    int signalHandlerFd;
     if(mSignalFdHandle)
     {
+      sh_poll_s sgPollData;
       if(E_OK!=getFDPollData(mSignalFdHandle, sgPollData))
       {
-          mSignalFdHandle = 0;
+         removeFDPoll(mSignalFdHandle);
+         mSignalFdHandle = 0;
+      }
+      else 
+      {
+        int signalHandlerFd = signalfd(sgPollData.pollfdValue.fd, &sigset, 0);
+        if (signalHandlerFd == -1)
+        {
+            logError("Could not update signal fd!");
+            return (E_NOT_POSSIBLE);
+        }
+        return E_OK;
       }
     }
     
     if(0==mSignalFdHandle)
     {
       /* Create the signalfd */
-      int signalHandlerFd = signalfd(-1, &sigset, SFD_NONBLOCK);
+      signalHandlerFd = signalfd(-1, &sigset, 0);
       if (signalHandlerFd == -1)
       {
           logError("Could not open signal fd!");
@@ -333,40 +320,21 @@ am_Error_e CAmSocketHandler::listenToSignals(const std::vector<uint8_t> & listSi
 
       auto actionPoll = [this](const pollfd pollfd, const sh_pollHandle_t, void*)
       {
-            const VectorSignalHandlers_t & signalHandlers = mSignalHandlers;
-            /* We have a valid signal, read the info from the fd */
-            struct signalfd_siginfo info;
-            ssize_t bytes = read(pollfd.fd, &info, sizeof(info));
-            if(bytes == -1)
-            {
-                if (errno == EAGAIN) //Something wrong, check for EAGAIN
-                    bytes = read(pollfd.fd, &info, sizeof(info)); 
-            }  
-            if(bytes != sizeof(info))
-            {
-                //Failed to read from fd...
-                logError("Failed to read from signal fd");
-                throw std::runtime_error(std::string("Failed to read from signal fd."));
-            }
+          const VectorSignalHandlers_t & signalHandlers = mSignalHandlers;
+          /* We have a valid signal, read the info from the fd */
+          struct signalfd_siginfo info;
+          ssize_t bytes = read(pollfd.fd, &info, sizeof(info));
+          assert(bytes == sizeof(info));
 
-            /* Notify all listeners */
-            for(auto it: signalHandlers)
-                it.callback(it.handle, info, it.userData);
+          /* Notify all listeners */
+          for(auto it: signalHandlers)
+          it.callback(it.handle, info, it.userData);
       };
       /* We're going to add the signal fd through addFDPoll. At this point we don't have any signal listeners. */
-      return addFDPoll(signalHandlerFd, POLLIN | POLLERR | POLLHUP, NULL, actionPoll, [](const sh_pollHandle_t, void*)
+      am_Error_e shFdError = addFDPoll(signalHandlerFd, POLLIN | POLLERR | POLLHUP, NULL, actionPoll, [](const sh_pollHandle_t, void*)
                                         {   return (false);}, NULL, NULL, mSignalFdHandle);
+      return shFdError;
     }    
-    else
-    {
-        int signalHandlerFd = signalfd(sgPollData.pollfdValue.fd, &sigset, 0);
-        if (signalHandlerFd == -1)
-        {
-            logError("Could not update signal fd!", strerror(errno));
-            return (E_NOT_POSSIBLE);
-        }
-        return E_OK;
-    }
 }
 
 /**
@@ -382,17 +350,10 @@ am_Error_e CAmSocketHandler::listenToSignals(const std::vector<uint8_t> & listSi
   * @return E_OK if the descriptor was added, E_NON_EXISTENT if the fd is not valid
   */
 
-am_Error_e CAmSocketHandler::addFDPoll(const int fd, 
-                                       const short event, 
-                                       std::function<void(const sh_pollHandle_t handle, void* userData)> prepare,
-                                       std::function<void(const pollfd pollfd, const sh_pollHandle_t handle, void* userData)> fired, 
-                                       std::function<bool(const sh_pollHandle_t handle, void* userData)> check,
-                                       std::function<bool(const sh_pollHandle_t handle, void* userData)> dispatch, 
-                                       void* userData, 
-                                       sh_pollHandle_t& handle)
+am_Error_e CAmSocketHandler::addFDPoll(const int fd, const short event, std::function<void(const sh_pollHandle_t handle, void* userData)> prepare,
+        std::function<void(const pollfd pollfd, const sh_pollHandle_t handle, void* userData)> fired, std::function<bool(const sh_pollHandle_t handle, void* userData)> check,
+        std::function<bool(const sh_pollHandle_t handle, void* userData)> dispatch, void* userData, sh_pollHandle_t& handle)
 {
-    CHECK_CALLER_THREAD_ID()
-    
     if (!fdIsValid(fd))
         return (E_NON_EXISTENT);
 
@@ -439,7 +400,7 @@ am::am_Error_e CAmSocketHandler::addFDPoll(const int fd, const short event, IAmS
 {
 
     std::function<void(const sh_pollHandle_t handle, void* userData)> prepareCB; //preperation callback
-    std::function<void(const pollfd pollfd, const sh_pollHandle_t handle, void* userData)> firedCB; //fired callback
+    std::function<void(const pollfd poll, const sh_pollHandle_t handle, void* userData)> firedCB; //fired callback
     std::function<bool(const sh_pollHandle_t handle, void* userData)> checkCB; //check callback
     std::function<bool(const sh_pollHandle_t handle, void* userData)> dispatchCB; //check callback
 
@@ -462,36 +423,19 @@ am::am_Error_e CAmSocketHandler::addFDPoll(const int fd, const short event, IAmS
   */
 am_Error_e CAmSocketHandler::removeFDPoll(const sh_pollHandle_t handle)
 {
-    CHECK_CALLER_THREAD_ID()
+    VectorListPoll_t::iterator iterator = mListPoll.begin();
 
-    bool handleRemoved = false;
-
-    for (auto it = mListPoll.begin(); it != mListPoll.end(); ++it)
+    for (; iterator != mListPoll.end(); ++iterator)
     {
-        if (it->handle == handle)
+        if (iterator->handle == handle)
         {
-            it = mListPoll.erase(it);
+            iterator = mListPoll.erase(iterator);
             mSetPollKeys.pollHandles.erase(handle);
-            handleRemoved = true;
-            break;
+            mRecreatePollfds = true;
+            return (E_OK);
         }
     }
-
-    if ( false == handleRemoved )
-        return (E_UNKNOWN);
-
-    mRecreatePollfds = true;
-
-    for (auto it = mListActivePolls.begin(); it != mListActivePolls.end(); ++it)
-    {
-        if (it->handle == handle)
-        {
-            it->isValid = false;
-            break;
-        }
-    }
-
-    return (E_OK);
+    return (E_UNKNOWN);
 }
 
 /**
@@ -503,8 +447,6 @@ am_Error_e CAmSocketHandler::removeFDPoll(const sh_pollHandle_t handle)
   */
 am_Error_e CAmSocketHandler::addSignalHandler(std::function<void(const sh_pollHandle_t handle, const signalfd_siginfo & info, void* userData)> callback, sh_pollHandle_t& handle, void * userData)
 {
-    CHECK_CALLER_THREAD_ID()
-    
     if (!nextHandle(mSetSignalhandlerKeys))
     {
         logError("Could not create new polls, too many open!");
@@ -527,8 +469,6 @@ am_Error_e CAmSocketHandler::addSignalHandler(std::function<void(const sh_pollHa
   */
 am_Error_e CAmSocketHandler::removeSignalHandler(const sh_pollHandle_t handle)
 {
-    CHECK_CALLER_THREAD_ID()
-    
     VectorSignalHandlers_t::iterator it(mSignalHandlers.begin());
     for (; it != mSignalHandlers.end(); ++it)
     {
@@ -566,7 +506,6 @@ am_Error_e CAmSocketHandler::addTimer(const timespec & timeouts, IAmShTimerCallB
 
 am_Error_e CAmSocketHandler::addTimer(const timespec & timeouts, std::function<void(const sh_timerHandle_t handle, void* userData)> callback, sh_timerHandle_t& handle, void * userData, const bool repeats)
 {
-    CHECK_CALLER_THREAD_ID()
     assert(!((timeouts.tv_sec == 0) && (timeouts.tv_nsec == 0)));
 
     mListTimer.emplace_back();
@@ -594,6 +533,7 @@ am_Error_e CAmSocketHandler::addTimer(const timespec & timeouts, std::function<v
     clock_gettime(CLOCK_MONOTONIC, &currentTime);
     if (!mDispatchDone)//the mainloop is started
     timerItem.countdown = timespecAdd(timeouts, timespecSub(currentTime, mStartTime));
+    mListTimer.push_back(timerItem);
     mListActiveTimer.push_back(timerItem);
     mListActiveTimer.sort(compareCountdown);
     return (E_OK);
@@ -619,35 +559,22 @@ am_Error_e CAmSocketHandler::addTimer(const timespec & timeouts, std::function<v
         return err;
     }
 
-    auto actionPoll = [this](const pollfd pollfd, const sh_pollHandle_t handle, void* userData)
+    static auto actionPoll = [](const pollfd pollfd, const sh_pollHandle_t handle, void* userData)
     {
         uint64_t mExpirations;
-        ssize_t bytes = read(pollfd.fd, &mExpirations, sizeof(mExpirations));
-        if(bytes == -1)
-        { 
-            if (errno == EAGAIN)//Something wrong, check for EAGAIN
-                bytes = read(pollfd.fd, &mExpirations, sizeof(mExpirations));
-        }
-
-        if(bytes != sizeof(mExpirations))
+        if (read(pollfd.fd, &mExpirations, sizeof(uint64_t)) == -1)
         {
-            //Failed to read from fd...
-            logError("Failed to read from timer fd");
-            throw std::runtime_error(std::string("Failed to read from timer fd."));
+            //error received...try again
+            read(pollfd.fd, &mExpirations, sizeof(uint64_t));
         }
     };
 
-    err = addFDPoll(timerItem.fd, 
-                    POLLIN, 
-                    NULL, 
-                    actionPoll, 
-                    [callback](const sh_pollHandle_t handle, void* userData)->bool{
-                        callback(handle, userData);
-                        return false;
-                    },
-                    NULL, 
-                    userData, 
-                    handle);
+    err = addFDPoll(timerItem.fd, POLLIN, NULL, actionPoll, [callback](const sh_pollHandle_t handle, void* userData)->bool
+    {
+        callback(handle, userData);
+        return false;
+    },
+    NULL, userData, handle);
     if (E_OK == err)
     {
         timerItem.handle = handle;
@@ -668,7 +595,6 @@ am_Error_e CAmSocketHandler::addTimer(const timespec & timeouts, std::function<v
   */
 am_Error_e CAmSocketHandler::removeTimer(const sh_timerHandle_t handle)
 {
-    CHECK_CALLER_THREAD_ID()
     assert(handle != 0);
 
     //stop the current timer
@@ -682,22 +608,20 @@ am_Error_e CAmSocketHandler::removeTimer(const sh_timerHandle_t handle)
     if (it == mListTimer.end())
         return (E_NON_EXISTENT);
 
-    mListRemovedTimers.push_back(*it);
+    close(it->fd);
     mListTimer.erase(it);
     return removeFDPoll(handle);
 #else
     stopTimer(handle);
     std::list<sh_timer_s>::iterator it(mListTimer.begin());
-    while (it != mListTimer.end())
+    for (; it != mListTimer.end(); ++it)
     {
         if (it->handle == handle)
         {
-            it = mListTimer.erase(it);            
+            it = mListTimer.erase(it);
             mSetTimerKeys.pollHandles.erase(handle);
             return (E_OK);
         }
-        else
-            ++it;
     }
     return (E_UNKNOWN);
 #endif
@@ -711,8 +635,6 @@ am_Error_e CAmSocketHandler::removeTimer(const sh_timerHandle_t handle)
   */
 am_Error_e CAmSocketHandler::updateTimer(const sh_timerHandle_t handle, const timespec & timeouts)
 {
-    CHECK_CALLER_THREAD_ID()
-    
 #ifdef WITH_TIMERFD
     std::list<sh_timer_s>::iterator it = mListTimer.begin();
     for (; it != mListTimer.end(); ++it)
@@ -735,7 +657,7 @@ am_Error_e CAmSocketHandler::updateTimer(const sh_timerHandle_t handle, const ti
     }
     else
     {
-        if (timerfd_settime(it->fd, 0, &it->countdown, NULL)<0)
+        if (timerfd_settime(it->fd, 0, &it->countdown, NULL))
         {
             logError("Failed to set timer duration");
             return E_NOT_POSSIBLE;
@@ -797,7 +719,6 @@ am_Error_e CAmSocketHandler::updateTimer(const sh_timerHandle_t handle, const ti
   */
 am_Error_e CAmSocketHandler::restartTimer(const sh_timerHandle_t handle)
 {
-    CHECK_CALLER_THREAD_ID()
 #ifdef WITH_TIMERFD
     std::list<sh_timer_s>::iterator it = mListTimer.begin();
     for (; it != mListTimer.end(); ++it)
@@ -816,7 +737,7 @@ am_Error_e CAmSocketHandler::restartTimer(const sh_timerHandle_t handle)
     }
     else
     {
-        if (timerfd_settime(it->fd, 0, &it->countdown, NULL)<0)
+        if (timerfd_settime(it->fd, 0, &it->countdown, NULL))
         {
             logError("Failed to set timer duration");
             return E_NOT_POSSIBLE;
@@ -876,7 +797,6 @@ am_Error_e CAmSocketHandler::restartTimer(const sh_timerHandle_t handle)
   */
 am_Error_e CAmSocketHandler::stopTimer(const sh_timerHandle_t handle)
 {
-    CHECK_CALLER_THREAD_ID()
 #ifdef WITH_TIMERFD
     std::list<sh_timer_s>::iterator it = mListTimer.begin();
     for (; it != mListTimer.end(); ++it)
@@ -891,7 +811,7 @@ am_Error_e CAmSocketHandler::stopTimer(const sh_timerHandle_t handle)
     countdown.it_value.tv_nsec = 0;
     countdown.it_value.tv_sec = 0;
 
-    if (timerfd_settime(it->fd, 0, &countdown, NULL)<0)
+    if (timerfd_settime(it->fd, 0, &countdown, NULL))
     {
         logError("Failed to set timer duration");
         return E_NOT_POSSIBLE;
@@ -900,16 +820,13 @@ am_Error_e CAmSocketHandler::stopTimer(const sh_timerHandle_t handle)
 #else   
     //go through the list and remove the timer with the handle
     std::list<sh_timer_s>::iterator it(mListActiveTimer.begin());
-    
-    while (it != mListActiveTimer.end())
+    for (; it != mListActiveTimer.end(); ++it)
     {
         if (it->handle == handle)
         {
             it = mListActiveTimer.erase(it);
             return (E_OK);
         }
-        else
-            it++;
     }
     return (E_NON_EXISTENT);
 #endif
@@ -923,7 +840,6 @@ am_Error_e CAmSocketHandler::stopTimer(const sh_timerHandle_t handle)
   */
 am_Error_e CAmSocketHandler::updateEventFlags(const sh_pollHandle_t handle, const short events)
 {
-    CHECK_CALLER_THREAD_ID()
     VectorListPoll_t::iterator iterator = mListPoll.begin();
 
     for (; iterator != mListPoll.end(); ++iterator)
@@ -1050,11 +966,11 @@ void CAmSocketHandler::prepare(am::CAmSocketHandler::sh_poll_s& row)
 /**
   * fire callback
   */
-void CAmSocketHandler::fire(const sh_poll_s* a)
+void CAmSocketHandler::fire(sh_poll_s& a)
 {
     try
     {
-        a->firedCB(a->pollfdValue, a->handle, a->userData);
+        a.firedCB(a.pollfdValue, a.handle, a.userData);
     } catch (std::exception& e)
     {
         logError("Sockethandler: Exception in Preparecallback,caught", e.what());
@@ -1064,23 +980,31 @@ void CAmSocketHandler::fire(const sh_poll_s* a)
 /**
   * should disptach
   */
-bool CAmSocketHandler::noDispatching(const sh_poll_s* a)
+bool CAmSocketHandler::noDispatching(const sh_poll_s& a)
 {
     //remove from list of there is no checkCB
-    if (nullptr == a->checkCB || false == a->isValid)
+    if (nullptr == a.checkCB)
         return (true);
-    return (!a->checkCB(a->handle, a->userData));
+    return (!a.checkCB(a.handle, a.userData));
 }
 
 /**
   * disptach
   */
-bool CAmSocketHandler::dispatchingFinished(const sh_poll_s* a)
+bool CAmSocketHandler::dispatchingFinished(const sh_poll_s& a)
 {
     //remove from list of there is no dispatchCB
-    if (nullptr == a->dispatchCB || false == a->isValid)
+    if (nullptr == a.dispatchCB)
         return (true);
-    return (!a->dispatchCB(a->handle, a->userData));
+    return (!a.dispatchCB(a.handle, a.userData));
+}
+
+/**
+  * event triggered
+  */
+bool CAmSocketHandler::eventFired(const pollfd& a)
+{
+    return (a.revents == 0 ? false : true);
 }
 
 /**
@@ -1097,41 +1021,30 @@ inline timespec* CAmSocketHandler::insertTime(timespec& buffertime)
         return (&buffertime);
     }
     else
-#endif
+#endif    
     {
         return (NULL);
     }
 }
 
-#ifdef WITH_TIMERFD
+#ifdef WITH_TIMERFD   
 am_Error_e CAmSocketHandler::createTimeFD(const itimerspec & timeouts, int & fd)
 {
     fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
-    if (fd < 0)
+    if (fd <= 0)
     {
         logError("Failed to create timer");
         return E_NOT_POSSIBLE;
     }
 
-    if (timerfd_settime(fd, 0, &timeouts, NULL) < 0)
+    if (timerfd_settime(fd, 0, &timeouts, NULL))
     {
         logError("Failed to set timer duration");
         return E_NOT_POSSIBLE;
     }
     return E_OK;
 }
-
-void CAmSocketHandler::closeRemovedTimers()
-{
-    for (auto it : mListRemovedTimers)
-    {
-        if( it.fd > -1 )
-            close( it.fd );
-    }
-    mListRemovedTimers.clear();
-}
-
-#endif
+#endif 
 
 void CAmSocketHandler::callTimer(sh_timer_s& a)
 {

--- a/AudioManagerUtilities/test/AmSerializerTest/CAmSerializerTest.cpp
+++ b/AudioManagerUtilities/test/AmSerializerTest/CAmSerializerTest.cpp
@@ -79,8 +79,6 @@ struct SerializerData
     V2::CAmSerializer *pSerializer;
 };
 
-#define ASYNCLOOP 100
-
 void* ptSerializerSync(void* data)
 {
     SerializerData *pData = (SerializerData*) data;
@@ -98,7 +96,6 @@ void* ptSerializerSync(void* data)
     return (NULL);
 }
 
-
 void* ptSerializerASync(void* data)
 {
     SerializerData *pData = (SerializerData*) data;
@@ -109,7 +106,7 @@ void* ptSerializerASync(void* data)
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    for (uint32_t i = 0; i < ASYNCLOOP; i++)
+    for (uint32_t i = 0; i < 5; i++)
     {
         testStr = pData->testStr;
         pData->pSerializer->asyncCall(pData->pSerCb, &MockIAmSerializerCb::dispatchData, i, testStr);
@@ -194,7 +191,7 @@ TEST(CAmSerializerTest, asyncTest)
 
     EXPECT_CALL(serCb,check()).Times(2);
     EXPECT_CALL(serCb,checkInt()).Times(1).WillRepeatedly(Return(100));
-    for (int i = 0; i < ASYNCLOOP; i++)
+    for (int i = 0; i < 5; i++)
         EXPECT_CALL(serCb,dispatchData(i,testStr)).WillOnce(DoAll(ActionDispatchData(), Return(true)));
 
     myHandler.start_listenting();

--- a/AudioManagerUtilities/test/AmSocketHandlerTest/CAmSocketHandlerTest.h
+++ b/AudioManagerUtilities/test/AmSocketHandlerTest/CAmSocketHandlerTest.h
@@ -101,21 +101,23 @@ namespace am
             UNIX, INET
         };
         CAmSamplePlugin(CAmSocketHandler *mySocketHandler, sockType_e socketType);
-        virtual ~CAmSamplePlugin(){ shutdown(mSocket, SHUT_RDWR); }
+        ~CAmSamplePlugin()
+        {
+        }
+        ;
         void connectSocket(const pollfd pollfd, const sh_pollHandle_t handle, void* userData);
-        virtual void receiveData(const pollfd pollfd, const sh_pollHandle_t handle, void* userData);
-        virtual bool dispatchData(const sh_pollHandle_t handle, void* userData);
-        virtual bool check(const sh_pollHandle_t handle, void* userData);
+        void receiveData(const pollfd pollfd, const sh_pollHandle_t handle, void* userData);
+        bool dispatchData(const sh_pollHandle_t handle, void* userData);
+        bool check(const sh_pollHandle_t handle, void* userData);
         TAmShPollFired<CAmSamplePlugin> connectFiredCB;
         TAmShPollFired<CAmSamplePlugin> receiveFiredCB;
         TAmShPollDispatch<CAmSamplePlugin> sampleDispatchCB;
         TAmShPollCheck<CAmSamplePlugin> sampleCheckCB;
-        bool isSocketOpened() { return mSocket>-1; }
-    protected:
+
+    private:
         CAmSocketHandler *mSocketHandler;
         sh_pollHandle_t mConnecthandle, mReceiveHandle;
         std::queue<std::string> msgList;
-        int mSocket;
     };
 
     class CAmTimerSockethandlerController: public MockIAmTimerCb
@@ -160,54 +162,6 @@ namespace am
         TAmShTimerCallBack<CAmTimer> pTimerCallback;
     };
 
-    class CAmTimerStressTest: public MockIAmTimerCb
-    {
-        CAmSocketHandler *mpSocketHandler;
-        timespec mUpdateTimeout;
-        int32_t mRepeats;
-        int32_t mId;
-        int32_t mHandle;
-    public:
-        explicit CAmTimerStressTest(CAmSocketHandler *SocketHandler, const timespec &timeout, const int32_t repeats = 0u);
-        virtual ~CAmTimerStressTest();
-        
-        int32_t getId() { return mId; }
-        void setId(const int32_t id) { mId=id; }
-
-        int32_t getHandle() { return mHandle; }
-        void setHandle(const int32_t id) { mHandle=id; }
-        
-        timespec getUpdateTimeout( ) { return mUpdateTimeout; }
-        
-        void timerCallback(sh_timerHandle_t handle, void * userData);
-
-        TAmShTimerCallBack<CAmTimerStressTest> pTimerCallback;
-    };
-    
-    class CAmTimerStressTest2: public MockIAmTimerCb
-    {
-        CAmSocketHandler *mpSocketHandler;
-        timespec mUpdateTimeout;
-        int32_t mRepeats;
-        int32_t mId;
-        int32_t mHandle;
-    public:
-        explicit CAmTimerStressTest2(CAmSocketHandler *SocketHandler, const timespec &timeout, const int32_t repeats = 0u);
-        virtual ~CAmTimerStressTest2();
-        
-        int32_t getId() { return mId; }
-        void setId(const int32_t id) { mId=id; }
-
-        int32_t getHandle() { return mHandle; }
-        void setHandle(const int32_t id) { mHandle=id; }
-        
-        timespec getUpdateTimeout( ) { return mUpdateTimeout; }
-
-        void timerCallback(sh_timerHandle_t handle, void * userData);
-
-        TAmShTimerCallBack<CAmTimerStressTest2> pTimerCallback;
-    };
-    
     class CAmTimerMeasurment: public MockIAmTimerCb
     {
         CAmSocketHandler *mSocketHandler;
@@ -233,20 +187,6 @@ namespace am
         ~CAmSocketHandlerTest();
         void SetUp();
         void TearDown();
-    };
-    
-    class CAmSamplePluginStressTest: public CAmSamplePlugin
-    {
-        std::vector<CAmTimerStressTest2*> mTimers;
-    public:
-        CAmSamplePluginStressTest(CAmSocketHandler *mySocketHandler, sockType_e socketType);
-        virtual ~CAmSamplePluginStressTest();
-        
-        void receiveData(const pollfd pollfd, const sh_pollHandle_t handle, void* userData) final;
-        bool dispatchData(const sh_pollHandle_t handle, void* userData) final;
-        bool check(const sh_pollHandle_t handle, void* userData) final;
-        
-        std::vector<CAmTimerStressTest2*> & getTimers() { return  mTimers; }
     };
 
 } /* namespace am */

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,10 +65,8 @@ option ( WITH_SHARED_CORE
     "Build audio manager core as dynamic library" OFF)
     
 option ( WITH_TIMERFD
-    "Build with timer fd support" ON )
+    "Build with the linux specific TIMERFD feature to support timing without using signals" ON)
     
-option( WITH_TESTS
-        "Build together with all available unitTest" ON )
 
 set(DBUS_SERVICE_PREFIX "org.genivi.audiomanager"
     CACHE PROPERTY "The dbus service prefix for the AM - only changable for legacy dbus")
@@ -214,6 +212,7 @@ if(WITH_DOCUMENTATION)
 		PATTERN "Doxyfile" EXCLUDE
 		PATTERN "def" EXCLUDE)
 endif(WITH_DOCUMENTATION)
+
 
 message(STATUS)
 message(STATUS "${PROJECT_NAME} Configuration:")


### PR DESCRIPTION
Reverts GENIVI/AudioManager#26 due to issues with the newly introduced thread_id runtime check.
Because the fix is spread over several patches the PR is requested to be removed.