### PR TITLE
Logging architecture

### DIFF
--- a/AudioManagerCore/src/CAmCommandReceiver.cpp
+++ b/AudioManagerCore/src/CAmCommandReceiver.cpp
@@ -26,7 +26,7 @@
 #include <algorithm>
 #include "IAmDatabaseHandler.h"
 #include "CAmControlSender.h"
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 #include "CAmSocketHandler.h"
 
 #define __METHOD_NAME__ std::string(std::string("CAmCommandReceiver::") + __func__)

--- a/AudioManagerCore/src/CAmCommandSender.cpp
+++ b/AudioManagerCore/src/CAmCommandSender.cpp
@@ -32,7 +32,7 @@
 #include <stdexcept>
 #include "CAmCommandReceiver.h"
 #include "TAmPluginTemplate.h"
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 #include "audiomanagerconfig.h"
 
 #define __METHOD_NAME__ std::string(std::string("CAmCommandSender::") + __func__)

--- a/AudioManagerCore/src/CAmControlReceiver.cpp
+++ b/AudioManagerCore/src/CAmControlReceiver.cpp
@@ -30,7 +30,7 @@
 #include "CAmRoutingSender.h"
 #include "CAmCommandSender.h"
 #include "CAmRouter.h"
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 #include "CAmSocketHandler.h"
 
 namespace am {

--- a/AudioManagerCore/src/CAmControlSender.cpp
+++ b/AudioManagerCore/src/CAmControlSender.cpp
@@ -32,7 +32,7 @@
 #include <sys/types.h>
 #include <dirent.h>
 #include "TAmPluginTemplate.h"
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 
 namespace am
 {

--- a/AudioManagerCore/src/CAmDatabaseHandlerMap.cpp
+++ b/AudioManagerCore/src/CAmDatabaseHandlerMap.cpp
@@ -31,7 +31,7 @@
 #include <limits>
 #include "CAmDatabaseHandlerMap.h"
 #include "CAmRouter.h"
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 
 static std::string __am_className__("CAmDatabaseHandlerMap::");
 #define __METHOD_NAME__ std::string(__am_className__ + __func__)

--- a/AudioManagerCore/src/CAmRouter.cpp
+++ b/AudioManagerCore/src/CAmRouter.cpp
@@ -29,7 +29,7 @@
 #include "CAmRouter.h"
 #include "IAmDatabaseHandler.h"
 #include "CAmControlSender.h"
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 
 namespace am
 {

--- a/AudioManagerCore/src/CAmRoutingReceiver.cpp
+++ b/AudioManagerCore/src/CAmRoutingReceiver.cpp
@@ -27,7 +27,7 @@
 #include "IAmDatabaseHandler.h"
 #include "CAmRoutingSender.h"
 #include "CAmControlSender.h"
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 #include "CAmSocketHandler.h"
 
 #define __METHOD_NAME__ std::string(std::string("CAmRoutingReceiver::") + __func__)

--- a/AudioManagerCore/src/CAmRoutingSender.cpp
+++ b/AudioManagerCore/src/CAmRoutingSender.cpp
@@ -34,7 +34,7 @@
 #include <stdexcept>
 #include "CAmRoutingReceiver.h"
 #include "TAmPluginTemplate.h"
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 #include "IAmDatabaseHandler.h"
 
 namespace am

--- a/AudioManagerCore/test/AmControlInterfaceTest/CAmControlInterfaceTest.cpp
+++ b/AudioManagerCore/test/AmControlInterfaceTest/CAmControlInterfaceTest.cpp
@@ -25,13 +25,12 @@
 #include <string>
 #include <vector>
 #include <set>
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 #include "CAmCommandLineSingleton.h"
 
 using namespace am;
 using namespace testing;
 
-DLT_DECLARE_CONTEXT(AudioManager)
 TCLAP::SwitchArg enableDebug ("V","logDlt","print DLT logs to stdout or dlt-daemon default on",true);
 
 ACTION(returnResyncConnection)
@@ -71,7 +70,6 @@ CAmControlInterfaceTest::CAmControlInterfaceTest() :
 
 CAmControlInterfaceTest::~CAmControlInterfaceTest()
 {
-	CAmDltWrapper::instance()->unregisterContext(AudioManager);
 }
 
 void CAmControlInterfaceTest::SetUp()
@@ -663,7 +661,8 @@ int main(int argc, char **argv)
 	catch (TCLAP::ArgException &e)  // catch any exceptions
 	{ std::cerr << "error: " << e.error() << " for arg " << e.argId() << std::endl; }
 	CAmCommandLineSingleton::instance()->preparse(argc,argv);
-	CAmDltWrapper::instanctiateOnce("ATEST","AudioManagerControlInterface Test",enableDebug.getValue(),CAmDltWrapper::logDestination::DAEMON);
+	CAmLogWrapper::instantiateOnce("ATEST","AudioManagerControlInterface Test"
+	        ,enableDebug.getValue() ? LS_ON : LS_OFF, LOG_SERVICE_DLT);
 	logInfo("RoutingSendInterface Test started");
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/AudioManagerCore/test/AmControlInterfaceTest/CAmControlInterfaceTest.h
+++ b/AudioManagerCore/test/AmControlInterfaceTest/CAmControlInterfaceTest.h
@@ -40,7 +40,6 @@
 #include "../MockIAmControlSend.h"
 #include "CAmSocketHandler.h"
 
-DLT_DECLARE_CONTEXT(textContext)          
 
 namespace am
 {

--- a/AudioManagerCore/test/AmMapHandlerTest/CAmMapHandlerTest.cpp
+++ b/AudioManagerCore/test/AmMapHandlerTest/CAmMapHandlerTest.cpp
@@ -27,7 +27,7 @@
 #include <vector>
 #include <set>
 #include <ios>
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 #include "CAmCommandLineSingleton.h"
 
 using namespace am;
@@ -3550,7 +3550,8 @@ int main(int argc, char **argv)
     catch (TCLAP::ArgException &e)  // catch any exceptions
     { std::cerr << "error: " << e.error() << " for arg " << e.argId() << std::endl; }
     CAmCommandLineSingleton::instance()->preparse(argc,argv);
-        CAmDltWrapper::instanctiateOnce("DTEST","Database Test",enableDebug.getValue(),CAmDltWrapper::logDestination::DAEMON);
+    CAmLogWrapper::instantiateOnce("DTEST","Database Test"
+            ,enableDebug.getValue() ? LS_ON : LS_OFF, LOG_SERVICE_DLT);
     logInfo("Database Test started ");
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/AudioManagerCore/test/AmRouterMapTest/CAmRouterMapTest.cpp
+++ b/AudioManagerCore/test/AmRouterMapTest/CAmRouterMapTest.cpp
@@ -24,7 +24,7 @@
 #include <chrono>
 #include "CAmRouterMapTest.h"
 #include <string.h>
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 #include "CAmCommandLineSingleton.h"
 
 TCLAP::SwitchArg enableDebug("V", "logDlt", "print DLT logs to stdout or dlt-daemon default off", false);
@@ -3774,7 +3774,8 @@ int main(int argc, char **argv)
         std::cerr << "error: " << e.error() << " for arg " << e.argId() << std::endl;
     }
     CAmCommandLineSingleton::instance()->preparse(argc, argv);
-    CAmDltWrapper::instanctiateOnce("rTEST", "RouterMap Test", enableDebug.getValue(), CAmDltWrapper::logDestination::DAEMON);
+    CAmLogWrapper::instantiateOnce("rTEST", "RouterMap Test"
+            , enableDebug.getValue() ? LS_ON : LS_OFF, LOG_SERVICE_DLT);
     logInfo("Routing Test started ");
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/AudioManagerCore/test/AmRouterTest/CAmRouterTest.cpp
+++ b/AudioManagerCore/test/AmRouterTest/CAmRouterTest.cpp
@@ -22,7 +22,7 @@
 
 #include "CAmRouterTest.h"
 #include <string.h>
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 #include "CAmCommandLineSingleton.h"
 
 using namespace am;
@@ -1974,7 +1974,8 @@ int main(int argc, char **argv)
 	catch (TCLAP::ArgException &e)  // catch any exceptions
 	{ std::cerr << "error: " << e.error() << " for arg " << e.argId() << std::endl; }
 	CAmCommandLineSingleton::instance()->preparse(argc,argv);
-		CAmDltWrapper::instanctiateOnce("RTEST","Router Test",enableDebug.getValue(),CAmDltWrapper::logDestination::DAEMON);
+	CAmLogWrapper::instantiateOnce("RTEST","Router Test"
+	        ,enableDebug.getValue() ? LS_ON : LS_OFF, LOG_SERVICE_DLT);
     logInfo("Routing Test started ");
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/AudioManagerCore/test/AmRoutingInterfaceTest/CAmRoutingInterfaceTest.cpp
+++ b/AudioManagerCore/test/AmRoutingInterfaceTest/CAmRoutingInterfaceTest.cpp
@@ -21,7 +21,7 @@
  */
 
 #include "CAmRoutingInterfaceTest.h"
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 #include "CAmCommandLineSingleton.h"
 
 using namespace am;
@@ -655,7 +655,8 @@ int main(int argc, char **argv)
 	catch (TCLAP::ArgException &e)  // catch any exceptions
 	{ std::cerr << "error: " << e.error() << " for arg " << e.argId() << std::endl; }
 	CAmCommandLineSingleton::instance()->preparse(argc,argv);
-		CAmDltWrapper::instanctiateOnce("RTEST","RoutingInterface Test",enableDebug.getValue(),CAmDltWrapper::logDestination::COMMAND_LINE);
+	CAmLogWrapper::instantiateOnce("RTEST","RoutingInterface Test"
+	        , enableDebug.getValue() ? LS_ON : LS_OFF, LOG_SERVICE_STDOUT);
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/AudioManagerDaemon/src/main.cpp
+++ b/AudioManagerDaemon/src/main.cpp
@@ -55,7 +55,7 @@
 #include "CAmRoutingReceiver.h"
 #include "CAmCommandReceiver.h"
 #include "CAmControlReceiver.h"
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 #include "CAmSocketHandler.h"
 #include "CAmCommandLineSingleton.h"
 #include "CAmDatabaseHandlerMap.h"
@@ -244,7 +244,9 @@ void mainProgram(int argc, char *argv[])
         daemonize();
     }
 
-    CAmDltWrapper::instanctiateOnce(AUDIOMANGER_APP_ID, AUDIOMANGER_APP_DESCRIPTION, dltEnable.getValue(), static_cast<am::CAmDltWrapper::logDestination>(dltOutput.getValue()), dltLogFilename.getValue());
+    CAmLogWrapper::instantiateOnce(AUDIOMANGER_APP_ID, AUDIOMANGER_APP_DESCRIPTION
+            , dltEnable.getValue() ? LS_ON : LS_OFF, static_cast<am::am_LogService_e>(dltOutput.getValue())
+            , dltLogFilename.getValue());
 
     // Instantiate all classes. Keep in same order !
     CAmSocketHandler iSocketHandler;

--- a/AudioManagerUtilities/CMakeLists.txt
+++ b/AudioManagerUtilities/CMakeLists.txt
@@ -40,6 +40,9 @@ ENDIF (WITH_SHARED_UTILITIES)
 SET(AUDIO_MANAGER_UTILITIES_SRCS_CXX
 	src/CAmCommandLineSingleton.cpp
 	src/CAmDltWrapper.cpp
+	src/CAmLogWrapper.cpp
+	src/CAmLoggerFile.cpp
+	src/CAmLoggerStdOut.cpp
 	src/CAmSocketHandler.cpp)
 
 if(WITH_SYSTEMD_WATCHDOG)
@@ -108,6 +111,10 @@ ENDIF (WITH_CAPI_WRAPPER)
 
 IF (WITH_DLT)
 	pkg_check_modules(DLT REQUIRED "automotive-dlt >= 2.2.0")
+
+    SET(AUDIO_MANAGER_UTILITIES_SRCS_CXX
+        ${AUDIO_MANAGER_UTILITIES_SRCS_CXX}
+        src/CAmLoggerDlt.cpp)
 
 	add_definitions(${DLT_CFLAGS_OTHER})
 

--- a/AudioManagerUtilities/include/CAmLogWrapper.h
+++ b/AudioManagerUtilities/include/CAmLogWrapper.h
@@ -1,0 +1,128 @@
+/**
+ * SPDX license identifier: MPL-2.0
+ *
+ * Copyright (C) 2017, ADIT GmbH
+ *
+ * \author Mattia Guerra, mguerra@de.adit-jv.com ADIT 2017
+ * \author Jens Lorenz, jlorenz@de.adit-jv.com ADIT 2017
+ *
+ * \copyright
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a  copy of the MPL was not distributed with
+ * this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * \file CAmLogWrapper.h
+ * For further information see http://www.genivi.org/.
+ */
+
+#ifndef LOGWRAPPER_H_
+#define LOGWRAPPER_H_
+
+#include <audiomanagerconfig.h>
+#include "pthread.h"
+#include "IAmLogger.h"
+#include "audiomanagertypes.h"
+
+namespace am
+{
+/**
+ * This class is instantiated as a singleton and offers logging to a default context (maincontext).
+ * Logging under the default context can simply be done with the logDebug/logInfo/logError/logWarning/logVerbose
+ * templates. For logging with a different context, you need to register a context with registerContext,
+ * method provided by backends implementing the IAmLogger interface. registerContext returns a logging context.
+ * To import this context into other classes use importContext, method provided by backends implementing the IAmLogger
+ * interface. To access the IAmLogger interface, simply ask CAmLogWrapper::instance().
+ */
+class CAmLogWrapper
+{
+public:
+    static IAmLogger *instantiateOnce(const char *appid, const char *description,
+        const am_LogStatus_e logStatus = LS_ON, const am_LogService_e logService = DEFAULT_LOG_SERVICE,
+        const std::string Filename = "", bool onlyError = false);
+    static IAmLogger *instance(const am_LogService_e logservice = DEFAULT_LOG_SERVICE);
+
+    inline static am_LogService_e getLogService()
+    {
+        return mLogService;
+    }
+
+    virtual ~CAmLogWrapper();
+
+private:
+    CAmLogWrapper(void);             //!< is private because of singleton pattern
+    static IAmLogger      *mpLogger; //!< pointer to the logger instance
+    static std::string     mAppId;
+    static std::string     mDescription;
+    static am_LogStatus_e  mLogStatus;
+    static am_LogService_e mLogService;
+    static std::string     mFilename;
+    static bool            mOnlyError;
+};
+
+/**
+ * returns the instance of instantiated IAmLogger
+ * @return
+ */
+inline IAmLogger *getLogger()
+{
+    return (CAmLogWrapper::instance(CAmLogWrapper::getLogService()));
+}
+
+/**
+ * logs given values with debuglevel with the default context
+ * @param value
+ * @param ...
+ */
+template<typename T, typename... TArgs>
+void logDebug(const T &value, const TArgs & ... args)
+{
+    getLogger()->logToDefaultContext(LL_DEBUG, value, args...);
+}
+
+/**
+ * logs given values with infolevel with the default context
+ * @param value
+ * @param ...
+ */
+template<typename T, typename... TArgs>
+void logInfo(const T &value, const TArgs & ... args)
+{
+    getLogger()->logToDefaultContext(LL_INFO, value, args...);
+}
+
+/**
+ * logs given values with errorlevel with the default context
+ * @param value
+ * @param ...
+ */
+template<typename T, typename... TArgs>
+void logError(const T &value, const TArgs & ... args)
+{
+    getLogger()->logToDefaultContext(LL_ERROR, value, args...);
+}
+
+/**
+ * logs given values with warninglevel with the default context
+ * @param value
+ * @param ...
+ */
+template<typename T, typename... TArgs>
+void logWarning(const T &value, const TArgs & ... args)
+{
+    getLogger()->logToDefaultContext(LL_WARN, value, args...);
+}
+
+/**
+ * logs given values with verboselevel with the default context
+ * @param value
+ * @param ...
+ */
+template<typename T, typename... TArgs>
+void logVerbose(const T &value, const TArgs & ... args)
+{
+    getLogger()->logToDefaultContext(LL_VERBOSE, value, args...);
+}
+
+}
+
+#endif /* LOGWRAPPER_H_ */

--- a/AudioManagerUtilities/include/CAmLoggerDlt.h
+++ b/AudioManagerUtilities/include/CAmLoggerDlt.h
@@ -1,0 +1,90 @@
+/**
+ * SPDX license identifier: MPL-2.0
+ *
+ * Copyright (C) 2017, ADIT GmbH
+ *
+ * This file is part of GENIVI Project AudioManager.
+ *
+ * Contributions are licensed to the GENIVI Alliance under one or more
+ * Contribution License Agreements.
+ *
+ * \copyright
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a  copy of the MPL was not distributed with
+ * this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * \file CAmLoggerDlt.h
+ * For further information see http://www.genivi.org/.
+ */
+
+#ifndef LOGGERDLT_H_
+#define LOGGERDLT_H_
+
+#include "IAmLogger.h"
+#include <dlt/dlt.h>
+#include <map>
+#include <string>
+#include <string.h>
+#include <vector>
+
+namespace am
+{
+
+class CAmLogContextDlt : public IAmLogContext
+{
+public:
+    CAmLogContextDlt(const char *id);
+    virtual ~CAmLogContextDlt() {}
+    DltContext *getHandle();
+
+private:
+    /* IAmLogContext */
+    bool configure(const am_LogLevel_e loglevel) override;
+    void send() override;
+    void append(const int8_t value) override;
+    void append(const uint8_t value) override;
+    void append(const int16_t value) override;
+    void append(const uint16_t value) override;
+    void append(const int32_t value) override;
+    void append(const uint32_t value) override;
+    void append(const uint64_t value) override;
+    void append(const int64_t value) override;
+    void append(const bool value) override;
+    void append(const std::vector<uint8_t> &data) override;
+    void append(const char *value) override;
+
+    template<class T>
+    void append(T value);
+
+    bool checkLogLevel(const am_LogLevel_e logLevel) override;
+
+private:
+    const char    *mId;
+    DltContext     mDltContext;
+    DltContextData mDltContextData;
+};
+
+class CAmLoggerDlt : public IAmLogger
+{
+public:
+    ~CAmLoggerDlt();
+
+    /* IAmLogger */
+    void registerApp(const char *appid, const char *description) override;
+    void unregisterApp() override;
+    IAmLogContext &registerContext(const char *contextid, const char *description) override;
+    IAmLogContext &registerContext(const char *contextid, const char *description,
+        const am_LogLevel_e level, const am_LogStatus_e status) override;
+    IAmLogContext &importContext(const char *contextid = NULL) override;
+    void unregisterContext(const char *contextid) override;
+
+private:
+    CAmLogContextDlt &createContext(const char *contextid);
+
+private:
+    std::map<const char *, CAmLogContextDlt *> mCtxTable;
+};
+
+}
+
+#endif /* LOGGERDLT_H_ */

--- a/AudioManagerUtilities/include/CAmLoggerFile.h
+++ b/AudioManagerUtilities/include/CAmLoggerFile.h
@@ -1,0 +1,105 @@
+/**
+ * SPDX license identifier: MPL-2.0
+ *
+ * Copyright (C) 2017, ADIT GmbH
+ *
+ * This file is part of GENIVI Project AudioManager.
+ *
+ * Contributions are licensed to the GENIVI Alliance under one or more
+ * Contribution License Agreements.
+ *
+ * \copyright
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a  copy of the MPL was not distributed with
+ * this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * \file CAmLoggerFile.h
+ * For further information see http://www.genivi.org/.
+ */
+
+#ifndef LOGGERFILE_H_
+#define LOGGERFILE_H_
+
+#include "IAmLogger.h"
+#include <map>
+#include <string>
+#include <string.h>
+#include <fstream>
+
+namespace am
+{
+
+class CFileHeader
+{
+public:
+    CFileHeader(const char *ctx = "LOG")
+        : mCtx(ctx) {}
+    friend std ::ostream &operator <<(std::ostream &out, const CFileHeader &h);
+
+    const char *mCtx;
+};
+
+class CAmLogContextFile : public IAmLogContext
+{
+public:
+    CAmLogContextFile(const char *id, const am_LogLevel_e level, const am_LogStatus_e status, std::ofstream &filestream);
+    virtual ~CAmLogContextFile() {}
+
+    /* IAmLogContext */
+    bool checkLogLevel(const am_LogLevel_e logLevel) override;
+
+private:
+    /* IAmLogContext */
+    bool configure(const am_LogLevel_e loglevel) override;
+    void send() override;
+    void append(const int8_t value) override;
+    void append(const uint8_t value) override;
+    void append(const int16_t value) override;
+    void append(const uint16_t value) override;
+    void append(const int32_t value) override;
+    void append(const uint32_t value) override;
+    void append(const uint64_t value) override;
+    void append(const int64_t value) override;
+    void append(const bool value) override;
+    void append(const std::vector<uint8_t> &data) override;
+    void append(const char *value) override;
+
+    template<class T>
+    void appendFile(T value);
+
+private:
+    CFileHeader    mHeader;
+    am_LogLevel_e  mLogLevel;
+    am_LogStatus_e mLogStatus;
+    std::ofstream &mFilestream;
+};
+
+class CAmLoggerFile : public IAmLogger
+{
+public:
+    CAmLoggerFile(const am_LogStatus_e status, const bool onlyError = false, const std::string &filename = "");
+    ~CAmLoggerFile();
+
+    /* IAmLogger */
+    void registerApp(const char *appid, const char *description) override;
+    void unregisterApp() override;
+    IAmLogContext &registerContext(const char *contextid, const char *description) override;
+    IAmLogContext &registerContext(const char *contextid, const char *description,
+        const am_LogLevel_e level, const am_LogStatus_e status) override;
+    IAmLogContext &importContext(const char *contextid = NULL) override;
+    void unregisterContext(const char *contextid) override;
+
+private:
+    void print(std::string str);
+
+private:
+    CFileHeader          mHeader;
+    const am_LogStatus_e mLogStatus;
+    const am_LogLevel_e  mStandardLogLevel;
+    std::ofstream        mFilestream;
+    std::map<const char *, CAmLogContextFile *> mCtxTable;
+};
+
+}
+
+#endif /* LOGGERFILE_H_ */

--- a/AudioManagerUtilities/include/CAmLoggerStdOut.h
+++ b/AudioManagerUtilities/include/CAmLoggerStdOut.h
@@ -1,0 +1,113 @@
+/**
+ * SPDX license identifier: MPL-2.0
+ *
+ * Copyright (C) 2015, ADIT GmbH
+ *
+ * This file is part of GENIVI Project AudioManager.
+ *
+ * Contributions are licensed to the GENIVI Alliance under one or more
+ * Contribution License Agreements.
+ *
+ * \copyright
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a  copy of the MPL was not distributed with
+ * this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * \file CAmLoggerStdOut.h
+ * For further information see http://www.genivi.org/.
+ */
+
+#ifndef LOGGERSTDOUT_H_
+#define LOGGERSTDOUT_H_
+
+#include "IAmLogger.h"
+#include <map>
+#include <string>
+#include <string.h>
+
+namespace am
+{
+
+static const std::string CC_BLACK   = "\x1b[0;30m";
+static const std::string CC_RED     = "\x1b[0;31m";
+static const std::string CC_GREEN   = "\x1b[0;32m";
+static const std::string CC_YELLOW  = "\x1b[0;33m";
+static const std::string CC_BLUE    = "\x1b[0;34m";
+static const std::string CC_MAGENTA = "\x1b[0;35m";
+static const std::string CC_CYAN    = "\x1b[0;36m";
+static const std::string CC_WHITE   = "\x1b[0;37m";
+static const std::string CC_RESET   = "\x1b[0;39m";
+
+class CStdOutHeader
+{
+public:
+    CStdOutHeader(const char *ctx = "LOG", const std::string &color = CC_BLUE)
+        : mCtx(ctx)
+        , mCc(color) {}
+    friend std ::ofstream &operator <<(std::ofstream &out, const CStdOutHeader &h);
+
+    const char        *mCtx;
+    const std::string &mCc;
+};
+
+class CAmLogContextStdOut : public IAmLogContext
+{
+public:
+    CAmLogContextStdOut(const char *id, const am_LogLevel_e level, const am_LogStatus_e status);
+    virtual ~CAmLogContextStdOut() {}
+
+    void changeLogLS(const am_LogLevel_e level, const am_LogStatus_e status);
+
+    /* IAmLogContext */
+    bool checkLogLevel(const am_LogLevel_e logLevel) override;
+
+private:
+    /* IAmLogContext */
+    bool configure(const am_LogLevel_e loglevel) override;
+    void send() override;
+    void append(const int8_t value) override;
+    void append(const uint8_t value) override;
+    void append(const int16_t value) override;
+    void append(const uint16_t value) override;
+    void append(const int32_t value) override;
+    void append(const uint32_t value) override;
+    void append(const uint64_t value) override;
+    void append(const int64_t value) override;
+    void append(const bool value) override;
+    void append(const std::vector<uint8_t> &data) override;
+    void append(const char *value) override;
+
+    template<class T>
+    void appendStdOut(T value);
+
+private:
+    CStdOutHeader  mHeader;
+    am_LogLevel_e  mLogLevel;
+    am_LogStatus_e mLogStatus;
+};
+
+class CAmLoggerStdOut : public IAmLogger
+{
+public:
+    CAmLoggerStdOut(const am_LogStatus_e status, const bool onlyError = false);
+    ~CAmLoggerStdOut();
+
+    /* IAmLogger */
+    void registerApp(const char *appid, const char *description) override;
+    void unregisterApp() override;
+    IAmLogContext &registerContext(const char *contextid, const char *description) override;
+    IAmLogContext &registerContext(const char *contextid, const char *description,
+        const am_LogLevel_e level, const am_LogStatus_e status) override;
+    IAmLogContext &importContext(const char *contextid = NULL) override;
+    void unregisterContext(const char *contextid) override;
+
+private:
+    CStdOutHeader        mHeader;
+    const am_LogStatus_e mLogStatus;
+    const am_LogLevel_e  mStandardLogLevel;
+    std::map<const char *, CAmLogContextStdOut *> mCtxTable;
+};
+
+}
+
+#endif /* LOGGERSTDOUT_H_ */

--- a/AudioManagerUtilities/include/CAmSerializer.h
+++ b/AudioManagerUtilities/include/CAmSerializer.h
@@ -23,7 +23,7 @@
 #include <memory>
 #include <stdexcept>
 #include <unistd.h>
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 #include "CAmSocketHandler.h"
 
 /*!

--- a/AudioManagerUtilities/include/CAmTimeUtility.h
+++ b/AudioManagerUtilities/include/CAmTimeUtility.h
@@ -1,0 +1,45 @@
+/**
+ * SPDX license identifier: MPL-2.0
+ *
+ * Copyright (C) 2016, ADIT GmbH
+ *
+ * This file is part of GENIVI Project AudioManager.
+ *
+ * Contributions are licensed to the GENIVI Alliance under one or more
+ * Contribution License Agreements.
+ *
+ * \copyright
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a  copy of the MPL was not distributed with
+ * this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * \file CAmTimeUtility.h
+ * For further information see http://www.genivi.org/.
+ */
+
+#ifndef TIMEUTILITY_H_
+#define TIMEUTILITY_H_
+
+#include <string>
+
+namespace am
+{
+
+class CAmTimeUtility
+{
+public:
+    static inline std::string now()
+    {
+        time_t     t(std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()));
+        struct tm *timeinfo(localtime(&t));
+        char       buffer[80];
+        strftime(buffer, 80, "%D %T ", timeinfo);
+        return (std::string(buffer));
+    }
+
+    virtual ~CAmTimeUtility();
+};
+
+}
+
+#endif /* TIMEUTILITY_H_ */

--- a/AudioManagerUtilities/include/IAmLogger.h
+++ b/AudioManagerUtilities/include/IAmLogger.h
@@ -65,6 +65,9 @@ enum am_LogStatus_e
 
 class IAmLogContext
 {
+    // enable cooperation with legacy class CAmDltWrapper
+    friend class CAmDltWrapper;
+
 public:
     virtual ~IAmLogContext() {}
 

--- a/AudioManagerUtilities/include/IAmLogger.h
+++ b/AudioManagerUtilities/include/IAmLogger.h
@@ -1,0 +1,342 @@
+/**
+ * SPDX license identifier: MPL-2.0
+ *
+ * Copyright (C) 2015, ADIT GmbH
+ *
+ * \author Jens Lorenz, jlorenz@de.adit-jv.com ADIT 2015
+ *
+ * This file is part of GENIVI Project AudioManager.
+ *
+ * Contributions are licensed to the GENIVI Alliance under one or more
+ * Contribution License Agreements.
+ *
+ * \copyright
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a  copy of the MPL was not distributed with
+ * this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * \file IAmLogger.h
+ * For further information see http://www.genivi.org/.
+ */
+
+#ifndef LOGGER_H_
+#define LOGGER_H_
+
+#include <pthread.h>
+#include <stdint.h>
+#include <sstream>
+#include <vector>
+#include <cassert>
+#include "audiomanagertypes.h"
+
+
+namespace am
+{
+
+#define DEFAULT_CONTEXT     "DEF"
+#define DEFAULT_DESCRIPTION "default Context registered by DLT Logger Class"
+
+#define DEFAULT_LOG_SERVICE static_cast<am_LogService_e>(0)
+
+enum am_LogService_e
+{
+    LOG_SERVICE_DLT,
+    LOG_SERVICE_STDOUT,
+    LOG_SERVICE_FILE,
+    LOG_SERVICE_OFF
+};
+
+enum am_LogLevel_e
+{
+    LL_OFF     = 0x00, /**< Log level off */
+    LL_FATAL   = 0x01, /**< fatal system error */
+    LL_ERROR   = 0x02, /**< error with impact to correct functionality */
+    LL_WARN    = 0x03, /**< warning, correct behavior could not be ensured */
+    LL_INFO    = 0x04, /**< informational */
+    LL_DEBUG   = 0x05, /**< debug  */
+    LL_VERBOSE = 0x06  /**< highest grade of information */
+};
+
+enum am_LogStatus_e
+{
+    LS_OFF = 0x00,
+    LS_ON  = 0x01
+};
+
+class IAmLogContext
+{
+public:
+    virtual ~IAmLogContext() {}
+
+    /**
+     * logs given loglevel and given values
+     * @param loglevel
+     * @param ...
+     */
+    template<typename... TArgs>
+    void off(const TArgs & ... args)
+    {
+        this->log(LL_OFF, args...);
+    }
+
+    template<typename... TArgs>
+    void fatal(const TArgs & ... args)
+    {
+        this->log(LL_FATAL, args...);
+    }
+
+    template<typename... TArgs>
+    void error(const TArgs & ... args)
+    {
+        this->log(LL_ERROR, args...);
+    }
+
+    template<typename... TArgs>
+    void warn(const TArgs & ... args)
+    {
+        this->log(LL_WARN, args...);
+    }
+
+    template<typename... TArgs>
+    void info(const TArgs & ... args)
+    {
+        this->log(LL_INFO, args...);
+    }
+
+    template<typename... TArgs>
+    void debug(const TArgs & ... args)
+    {
+        this->log(LL_DEBUG, args...);
+    }
+
+    template<typename... TArgs>
+    void verbose(const TArgs & ... args)
+    {
+        this->log(LL_VERBOSE, args...);
+    }
+
+    template<typename... TArgs>
+    void log(const am_LogLevel_e loglevel, const TArgs & ... args)
+    {
+        if (!this->configure(loglevel))
+        {
+            return;
+        }
+
+        this->append(args...);
+        this->send();
+    }
+
+    virtual bool checkLogLevel(const am_LogLevel_e logLevel) = 0;
+
+    virtual bool configure(const am_LogLevel_e loglevel) = 0;
+
+private:
+    virtual void send() = 0;
+
+    virtual void append(const int8_t value)               = 0;
+    virtual void append(const uint8_t value)              = 0;
+    virtual void append(const int16_t value)              = 0;
+    virtual void append(const uint16_t value)             = 0;
+    virtual void append(const int32_t value)              = 0;
+    virtual void append(const uint32_t value)             = 0;
+    virtual void append(const uint64_t value)             = 0;
+    virtual void append(const int64_t value)              = 0;
+    virtual void append(const bool value)                 = 0;
+    virtual void append(const std::vector<uint8_t> &data) = 0;
+    virtual void append(const char *value)                = 0;
+
+    template<typename T = std::string &>
+    void append(const std::string &value)
+    {
+        this->append(value.c_str());
+    }
+
+    template<typename T>
+    void append_enum(const T &value, const T &tmax, const std::vector<const char *> &text)
+    {
+        assert(tmax == text.size());
+        try
+        {
+            this->append(text.at(value));
+        }
+        catch (const std::out_of_range &)
+        {
+            this->append(__PRETTY_FUNCTION__);
+            this->append(static_cast<int32_t>(value));
+            this->append("out of range!");
+        }
+    }
+
+    template<typename T = am_Error_e>
+    void append(const am_Error_e value)
+    {
+        this->append_enum(value, E_MAX, std::vector<const char *> {
+                "E_OK",
+                "E_UNKNOWN",
+                "E_OUT_OF_RANGE",
+                "E_NOT_USED",
+                "E_DATABASE_ERROR",
+                "E_ALREADY_EXISTS",
+                "E_NO_CHANGE",
+                "E_NOT_POSSIBLE",
+                "E_NON_EXISTENT",
+                "E_ABORTED",
+                "E_WRONG_FORMAT",
+                "E_COMMUNICATION"
+            }
+            );
+    }
+
+    template<typename T = am_SourceState_e>
+    void append(const am_SourceState_e value)
+    {
+        this->append_enum(value, SS_MAX, std::vector<const char *> {
+                "SS_UNKNNOWN",
+                "SS_ON",
+                "SS_OFF",
+                "SS_PAUSED"
+            }
+            );
+    }
+
+    template<typename T = am_MuteState_e>
+    void append(const am_MuteState_e value)
+    {
+        this->append_enum(value, MS_MAX, std::vector<const char *> {
+                "MS_UNKNOWN",
+                "MS_MUTED",
+                "MS_UNMUTED"
+            }
+            );
+    }
+
+    template<typename T = am_DomainState_e>
+    void append(const am_DomainState_e value)
+    {
+        this->append_enum(value, DS_MAX, std::vector<const char *> {
+                "DS_UNKNOWN",
+                "DS_CONTROLLED",
+                "DS_INDEPENDENT_STARTUP",
+                "DS_INDEPENDENT_RUNDOWN"
+            }
+            );
+    }
+
+    template<typename T = am_ConnectionState_e>
+    void append(const am_ConnectionState_e value)
+    {
+        this->append_enum(value, CS_MAX, std::vector<const char *> {
+                "CS_UNKNOWN",
+                "CS_CONNECTING",
+                "CS_CONNECTED",
+                "CS_DISCONNECTING",
+                "CS_DISCONNECTED",
+                "CS_SUSPENDED"
+            }
+            );
+    }
+
+    template<typename T = am_Availability_e>
+    void append(const am_Availability_e value)
+    {
+        this->append_enum(value, A_MAX, std::vector<const char *> {
+                "A_UNKNOWN",
+                "A_AVAILABLE",
+                "A_UNAVAILABLE"
+            }
+            );
+    }
+
+    template<typename T = am_InterruptState_e>
+    void append(const am_InterruptState_e value)
+    {
+        this->append_enum(value, IS_MAX, std::vector<const char *> {
+                "IS_UNKNOWN",
+                "IS_OFF",
+                "IS_INTERRUPTED"
+            }
+            );
+    }
+
+    template<typename T = am_Handle_e>
+    void append(const am_Handle_e value)
+    {
+        this->append_enum(value, H_MAX, std::vector<const char *> {
+                "H_UNKNOWN",
+                "H_CONNECT",
+                "H_DISCONNECT",
+                "H_SETSOURCESTATE",
+                "H_SETSINKVOLUME",
+                "H_SETSOURCEVOLUME",
+                "H_SETSINKSOUNDPROPERTY",
+                "H_SETSOURCESOUNDPROPERTY",
+                "H_SETSINKSOUNDPROPERTIES",
+                "H_SETSOURCESOUNDPROPERTIES",
+                "H_CROSSFADE",
+                "H_SETVOLUMES",
+                "H_SETSINKNOTIFICATION",
+                "H_SETSOURCENOTIFICATION"
+            }
+            );
+    }
+
+    template<typename T = am_Handle_s>
+    void append(const am_Handle_s value)
+    {
+        this->append(value.handle);
+        this->append(value.handleType);
+    }
+
+    // Template to print unknown pointer types with their address
+    template<typename T>
+    void append(T *value)
+    {
+        std::ostringstream ss;
+        ss << "0x" << std::hex << (uint64_t)value;
+        this->append(ss.str().c_str());
+    }
+
+    // Template to print unknown types
+    template<typename T>
+    void append(T value)
+    {
+        std::ostringstream ss;
+        ss << std::dec << value;
+        this->append(ss.str().c_str());
+    }
+
+    // Template parameter pack to generate recursive code
+    void append(void) {}
+    template<typename T, typename... TArgs>
+    void append(const T &value, const TArgs & ... args)
+    {
+        this->append(value);
+        this->append(args...);
+    }
+
+};
+
+class IAmLogger
+{
+public:
+    virtual ~IAmLogger() {}
+    virtual void registerApp(const char *appid, const char *description) = 0;
+    virtual void unregisterApp() = 0;
+    virtual IAmLogContext &registerContext(const char *contextid, const char *description) = 0;
+    virtual IAmLogContext &registerContext(const char *contextid, const char *description,
+        const am_LogLevel_e level, const am_LogStatus_e status) = 0;
+    virtual IAmLogContext &importContext(const char *contextid = NULL) = 0;
+    virtual void unregisterContext(const char *contextid)      = 0;
+
+    template<typename T, typename... TArgs>
+    void logToDefaultContext(const am_LogLevel_e loglevel, const T &value, const TArgs & ... args)
+    {
+        this->importContext().log(loglevel, value, args...);
+    }
+
+};
+
+}
+
+#endif // LOGGER_H_

--- a/AudioManagerUtilities/include/TAmPluginTemplate.h
+++ b/AudioManagerUtilities/include/TAmPluginTemplate.h
@@ -26,7 +26,7 @@
 
 #include <dlfcn.h>
 #include <libgen.h>
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 
 namespace am
 {

--- a/AudioManagerUtilities/src/CAmCommonAPIWrapper.cpp
+++ b/AudioManagerUtilities/src/CAmCommonAPIWrapper.cpp
@@ -27,7 +27,7 @@
 #include <vector>
 #include "audiomanagertypes.h"
 #include "CAmSocketHandler.h"
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 #include "CAmCommonAPIWrapper.h"
 
 namespace am

--- a/AudioManagerUtilities/src/CAmDbusWrapper.cpp
+++ b/AudioManagerUtilities/src/CAmDbusWrapper.cpp
@@ -29,7 +29,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <stdexcept>
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 #include "CAmSocketHandler.h"
 
 namespace am

--- a/AudioManagerUtilities/src/CAmDltWrapper.cpp
+++ b/AudioManagerUtilities/src/CAmDltWrapper.cpp
@@ -22,134 +22,26 @@
  *
  */
 
-#include <string>
-#include <iostream>
 #include <string.h>
-#include <chrono>
-#include <ctime>
-#include <sys/types.h>
 #include <unistd.h>
 #include "CAmDltWrapper.h"
+
+using namespace std;
+
 
 namespace am
 {
 CAmDltWrapper  *CAmDltWrapper::mpDLTWrapper = NULL;
-pthread_mutex_t CAmDltWrapper::mMutex       = PTHREAD_MUTEX_INITIALIZER;
 
-const std::vector<const char *> CAmDltWrapper::mStr_error =
-{
-    "E_OK",
-    "E_UNKNOWN",
-    "E_OUT_OF_RANGE",
-    "E_NOT_USED",
-    "E_DATABASE_ERROR",
-    "E_ALREADY_EXISTS",
-    "E_NO_CHANGE",
-    "E_NOT_POSSIBLE",
-    "E_NON_EXISTENT",
-    "E_ABORTED",
-    "E_WRONG_FORMAT",
-    "E_COMMUNICATION",
-    "E_MAX"
-};
-
-const std::vector<const char *> CAmDltWrapper::mStr_sourceState =
-{
-    "SS_UNKNNOWN",
-    "SS_ON",
-    "SS_OFF",
-    "SS_PAUSED",
-    "SS_MAX"
-};
-
-const std::vector<const char *> CAmDltWrapper::mStr_MuteState =
-{
-    "MS_UNKNOWN",
-    "MS_MUTED",
-    "MS_UNMUTED",
-    "MS_MAX"
-};
-
-const std::vector<const char *> CAmDltWrapper::mStr_DomainState =
-{
-    "DS_UNKNOWN",
-    "DS_CONTROLLED",
-    "DS_INDEPENDENT_STARTUP",
-    "DS_INDEPENDENT_RUNDOWN",
-    "DS_MAX"
-};
-
-const std::vector<const char *> CAmDltWrapper::mStr_ConnectionState =
-{
-    "CS_UNKNOWN",
-    "CS_CONNECTING",
-    "CS_CONNECTED",
-    "CS_DISCONNECTING",
-    "CS_DISCONNECTED",
-    "CS_SUSPENDED",
-    "CS_MAX"
-};
-
-const std::vector<const char *> CAmDltWrapper::mStr_Availability =
-{
-    "A_UNKNOWN",
-    "A_AVAILABLE",
-    "A_UNAVAILABLE",
-    "A_MAX"
-};
-
-const std::vector<const char *> CAmDltWrapper::mStr_Interrupt =
-{
-    "IS_UNKNOWN",
-    "IS_OFF",
-    "IS_INTERRUPTED",
-    "IS_MAX"
-};
-
-const std::vector<const char *> CAmDltWrapper::mStr_Handle =
-{
-    "H_UNKNOWN",
-    "H_CONNECT",
-    "H_DISCONNECT",
-    "H_SETSOURCESTATE",
-    "H_SETSINKVOLUME",
-    "H_SETSOURCEVOLUME",
-    "H_SETSINKSOUNDPROPERTY",
-    "H_SETSOURCESOUNDPROPERTY",
-    "H_SETSINKSOUNDPROPERTIES",
-    "H_SETSOURCESOUNDPROPERTIES",
-    "H_CROSSFADE",
-    "H_SETVOLUMES",
-    "H_SETSINKNOTIFICATION",
-    "H_SETSOURCENOTIFICATION",
-    "H_MAX"
-};
-
-const std::vector<const char *> CAmDltWrapper::mStr_NotificationStatus =
-{
-    "NS_UNKNOWN",
-    "NS_OFF",
-    "NS_PERIODIC",
-    "NS_MINIMUM",
-    "NS_MAXIMUM",
-    "NS_CHANGE",
-    "NS_MAX"
-};
-
-std::string CAmDltWrapper::now()
-{
-    std::time_t t(std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()));
-    struct tm  *timeinfo(localtime(&t));
-    char        buffer[80];
-    std::strftime(buffer, 80, "%D %T ", timeinfo);
-    return (std::string(buffer));
-}
 
 CAmDltWrapper *CAmDltWrapper::instanctiateOnce(const char *appid, const char *description, const bool debugEnabled, const logDestination logDest, const std::string Filename, bool onlyError)
 {
     if (!mpDLTWrapper)
     {
-        mpDLTWrapper = new CAmDltWrapper(appid, description, debugEnabled, logDest, Filename, onlyError);
+        IAmLogger *pLogger = CAmLogWrapper::instantiateOnce(appid, description
+                , (debugEnabled ? LS_ON : LS_OFF), static_cast<am_LogService_e>(logDest)
+                , Filename, onlyError);
+        mpDLTWrapper = new CAmDltWrapper(pLogger, debugEnabled, onlyError);
     }
 
     return (mpDLTWrapper);
@@ -162,8 +54,8 @@ CAmDltWrapper *CAmDltWrapper::instance()
         // an application seems not to use our CAmDltWrapper class therefore create default
         std::ostringstream description;
         description << "PID=" << getpid() << " _=" << getenv("_");
-        mpDLTWrapper = new CAmDltWrapper("AMDL", description.str().c_str());
-        std::cerr << "Application doesn't call CAmDltWrapper::instanciateOnce!!!" << std::endl;
+        mpDLTWrapper = instanctiateOnce("AMDL", description.str().c_str());
+        std::cerr << "Application doesn't call CAmDltWrapper::instanctiateOnce!!!" << std::endl;
         std::cerr << "-> CAmDltWrapper::instance registers DLT application [ AMDL | " << description.str() << " ]" << std::endl;
     }
 
@@ -175,321 +67,97 @@ bool CAmDltWrapper::getEnabled()
     return (mDebugEnabled);
 }
 
-bool CAmDltWrapper::initNoDlt(DltLogLevelType loglevel, DltContext *context)
+CAmDltWrapper::CAmDltWrapper(IAmLogger *pLogger, bool debugEnabled, bool onlyError)
+    : mpLogger(pLogger)
+    , mpCurrentContext(NULL)
+    , mDebugEnabled(debugEnabled)
+    , mOnlyError(onlyError)
 {
-    if (mlogDestination == logDestination::COMMAND_LINE)
-    {
-        if (!context)
-        {
-            switch (loglevel)
-            {
-            case DLT_LOG_OFF:
-            case DLT_LOG_FATAL:
-            case DLT_LOG_ERROR:
-                mNoDltContextData.buffer << "\033[0;31m" << "[DEF] [Erro] \033[0m";
-                mLogOn = true;
-                break;
-            case DLT_LOG_WARN:
-                if (!mOnlyError)
-                {
-                    mNoDltContextData.buffer << "\033[0;33m" << "[DEF] [Warn] \033[0m";
-                }
-                else
-                {
-                    mLogOn = false;
-                }
 
-                break;
-            case DLT_LOG_INFO:
-                if (!mOnlyError)
-                {
-                    mNoDltContextData.buffer << "\033[0;36m" << "[DEF] [Info] \033[0m";
-                }
-                else
-                {
-                    mLogOn = false;
-                }
-
-                break;
-            default:
-                if (!mOnlyError)
-                {
-                    mNoDltContextData.buffer << "\033[0;32m" << "[DEF] [Defa] \033[0m";
-                }
-                else
-                {
-                    mLogOn = false;
-                }
-            }
-        }
-        else
-        {
-            std::string con(mMapContext.at(context));
-            switch (loglevel)
-            {
-            case DLT_LOG_OFF:
-            case DLT_LOG_FATAL:
-            case DLT_LOG_ERROR:
-                mNoDltContextData.buffer << "\033[0;31m[" << con << "] [Erro] \033[0m";
-                mLogOn = true;
-                break;
-            case DLT_LOG_WARN:
-                if (!mOnlyError)
-                {
-                    mNoDltContextData.buffer << "\033[0;33m[" << con << "] [Warn] \033[0m";
-                }
-                else
-                {
-                    mLogOn = false;
-                }
-
-                break;
-            case DLT_LOG_INFO:
-                if (!mOnlyError)
-                {
-                    mNoDltContextData.buffer << "\033[0;36m[" << con << "]  [Info] \033[0m";
-                }
-                else
-                {
-                    mLogOn = false;
-                }
-
-                break;
-            default:
-                if (!mOnlyError)
-                {
-                    mNoDltContextData.buffer << "\033[0;32m[" << con << "]  [Defa] \033[0m";
-                }
-                else
-                {
-                    mLogOn = false;
-                }
-            }
-        }
-
-        return true;
-    }
-    else
-    {
-        if (!context)
-        {
-            switch (loglevel)
-            {
-            case DLT_LOG_OFF:
-            case DLT_LOG_FATAL:
-            case DLT_LOG_ERROR:
-                mNoDltContextData.buffer << "[DEF] [Erro] ";
-                mLogOn = true;
-                break;
-            case DLT_LOG_WARN:
-                if (!mOnlyError)
-                {
-                    mNoDltContextData.buffer << "[DEF] [Warn] ";
-                }
-                else
-                {
-                    mLogOn = false;
-                }
-
-                break;
-            case DLT_LOG_INFO:
-                if (!mOnlyError)
-                {
-                    mNoDltContextData.buffer << "[DEF] [Info] ";
-                }
-                else
-                {
-                    mLogOn = false;
-                }
-
-                break;
-            default:
-                if (!mOnlyError)
-                {
-                    mNoDltContextData.buffer << "[DEF] [Defa] ";
-                }
-                else
-                {
-                    mLogOn = false;
-                }
-            }
-        }
-        else
-        {
-            std::string con(mMapContext.at(context));
-            switch (loglevel)
-            {
-            case DLT_LOG_OFF:
-            case DLT_LOG_FATAL:
-            case DLT_LOG_ERROR:
-                mNoDltContextData.buffer << "[" << con << "] [Erro] ";
-                mLogOn = true;
-                break;
-            case DLT_LOG_WARN:
-                if (!mOnlyError)
-                {
-                    mNoDltContextData.buffer << "[" << con << "] [Warn] ";
-                }
-                else
-                {
-                    mLogOn = false;
-                }
-
-                break;
-            case DLT_LOG_INFO:
-                if (!mOnlyError)
-                {
-                    mNoDltContextData.buffer << "[" << con << "] [Info] ";
-                }
-                else
-                {
-                    mLogOn = false;
-                }
-
-                break;
-            default:
-                if (!mOnlyError)
-                {
-                    mNoDltContextData.buffer << "[" << con << "] [Defa] ";
-                }
-                else
-                {
-                    mLogOn = false;
-                }
-            }
-        }
-
-        return true;
-    }
-}
-
-#ifdef WITH_DLT
-CAmDltWrapper::CAmDltWrapper(const char *appid, const char *description, const bool debugEnabled, const logDestination logDest, const std::string Filename, bool onlyError)
-    : mDebugEnabled(debugEnabled)
-    ,                                //
-    mlogDestination(logDest)
-    ,                             //
-    mFilename(NULL)
-    ,                    //
-    mOnlyError(onlyError)
-    ,                          //
-    mLogOn(true)
-{
-    if (mDebugEnabled && mlogDestination == logDestination::DAEMON)
-    {
-        dlt_register_app(appid, description);
-        // register a default context
-        dlt_register_context(&mDltContext, "DEF", "Default Context registered by DLTWrapper Class");
-    }
-    else if (mDebugEnabled)
-    {
-        if (mlogDestination == logDestination::COMMAND_LINE)
-        {
-            std::cout << "\033[0;36m[DLT] Registering AppID " << appid << " , " << description << "\033[0m" << std::endl;
-        }
-        else
-        {
-            mFilename.open(Filename, std::ofstream::out | std::ofstream::trunc);
-            if (!mFilename.is_open())
-            {
-                throw std::runtime_error("Cannot open file for logging");
-            }
-
-            mFilename << now() << "[DLT] Registering AppID " << appid << " , " << description << std::endl;
-        }
-    }
 }
 
 CAmDltWrapper::~CAmDltWrapper()
 {
-    if (mpDLTWrapper && mDebugEnabled && mlogDestination == logDestination::DAEMON)
+    for (auto context : mMapContext)
     {
-        mpDLTWrapper->unregisterContext(mDltContext);
-        delete mpDLTWrapper;
+        unregisterContext(*(context.first));
     }
-    else if (mpDLTWrapper && mDebugEnabled && mlogDestination == logDestination::COMMAND_LINE)
-    {
-        mFilename.close();
-    }
+
+    delete mpLogger;
+    mpLogger = NULL;
+
+    mpDLTWrapper = NULL;
 }
 
 void CAmDltWrapper::unregisterContext(DltContext &handle)
 {
-    if (mDebugEnabled && mlogDestination == logDestination::DAEMON)
+    if (mpLogger)
     {
-        dlt_unregister_context(&handle);
+        string ctxID(handle.contextID, DLT_ID_SIZE);
+        mpLogger->unregisterContext(ctxID.c_str());
+        mMapContext.erase(&handle);
     }
 }
 
 void CAmDltWrapper::deinit()
 {
-    if (mDebugEnabled)
+    if (mpCurrentContext)
     {
-        unregisterContext(mDltContext);
+        mpCurrentContext->configure(mOnlyError ? LL_ERROR : LL_INFO);
     }
+    mpCurrentContext = NULL;
 }
 
 void CAmDltWrapper::registerContext(DltContext &handle, const char *contextid, const char *description)
 {
-    if (mDebugEnabled && mlogDestination == logDestination::DAEMON)
+    if (mpLogger)
     {
-        dlt_register_context(&handle, contextid, description);
-    }
-    else if (mDebugEnabled)
-    {
+        mpLogger->registerContext(contextid, description);
+        size_t len = min(DLT_ID_SIZE, 1 + (int)strlen(contextid));
+        strncpy(handle.contextID, contextid, len);
         mMapContext.emplace(&handle, std::string(contextid));
-
-        if (mlogDestination == logDestination::COMMAND_LINE)
-        {
-            std::cout << "\033[0;36m[DLT] Registering Context " << contextid << " , " << description << "\033[0m" << std::endl;
-        }
-        else
-        {
-            mFilename << now() << "[DLT] Registering Context " << contextid << " , " << description << std::endl;
-        }
     }
 }
 
-void CAmDltWrapper::registerContext(DltContext &handle, const char *contextid, const char *description, const DltLogLevelType level, const DltTraceStatusType status)
+void CAmDltWrapper::registerContext(DltContext &handle, const char *contextid, const char *description
+        , DltLogLevelType level, DltTraceStatusType status)
 {
-    if (mDebugEnabled && mlogDestination == logDestination::DAEMON)
+    if (mpLogger)
     {
-        dlt_register_context_ll_ts(&handle, contextid, description, level, status);
-    }
-    else if (mDebugEnabled)
-    {
-        mMapContext.emplace(&handle, std::string(contextid));
+        if (level == DLT_LOG_DEFAULT)
+        {
+            logWarning("CAmDltWrapper::registerContext - understanding DLT_LOG_DEFAULT as DLT_LOG_INFO");
+            level = DLT_LOG_INFO;
+        }
+        if (status == DLT_TRACE_STATUS_DEFAULT)
+        {
+            logError("CAmDltWrapper::registerContext - understanding DLT_TRACE_STATUS_DEFAULT as DLT_TRACE_STATUS_ON");
+            status = DLT_TRACE_STATUS_ON;
+        }
 
-        if (mlogDestination == logDestination::COMMAND_LINE)
-        {
-            std::cout << "\033[0;36m[DLT] Registering Context " << contextid << " , " << description << "\033[0m" << std::endl;
-        }
-        else
-        {
-            mFilename << now() << " [DLT] Registering Context " << contextid << " , " << description << std::endl;
-        }
+        size_t len = min(DLT_ID_SIZE, 1 + (int)strlen(contextid));
+        mpLogger->registerContext(contextid, description
+                , static_cast<am_LogLevel_e>(level), static_cast<am_LogStatus_e>(status));
+        strncpy(handle.contextID, contextid, len);
+        mMapContext.emplace(&handle, std::string(contextid));
     }
 }
+
 
 bool CAmDltWrapper::init(DltLogLevelType loglevel, DltContext *context)
 {
-    pthread_mutex_lock(&mMutex);
-    if (mlogDestination == logDestination::DAEMON)
+    if (mpLogger)
     {
-        if (!context)
+        if (context)
         {
-            context = &mDltContext;
+            string mCurrentContextID(context->contextID, DLT_ID_SIZE);
+            mpCurrentContext = &(mpLogger->importContext(mCurrentContextID.c_str()));
         }
-
-        if (dlt_user_log_write_start(context, &mDltContextData, loglevel) <= 0)
+        else
         {
-            pthread_mutex_unlock(&mMutex);
-            return false;
+            mpCurrentContext = &(mpLogger->importContext());
         }
-    }
-    else
-    {
-        initNoDlt(loglevel, context);
+        mpCurrentContext->configure(static_cast<am_LogLevel_e>(loglevel));
     }
 
     return true;
@@ -497,317 +165,11 @@ bool CAmDltWrapper::init(DltLogLevelType loglevel, DltContext *context)
 
 void CAmDltWrapper::send()
 {
-    if (mlogDestination == logDestination::DAEMON)
+    if (mpCurrentContext)
     {
-        dlt_user_log_write_finish(&mDltContextData);
+        mpCurrentContext->send();
     }
-    else
-    {
-        if (mlogDestination == logDestination::COMMAND_LINE && mLogOn)
-        {
-            std::cout << mNoDltContextData.buffer.str().c_str() << std::endl;
-        }
-        else if (mLogOn)
-        {
-            mFilename << now() << mNoDltContextData.buffer.str().c_str() << std::endl;
-        }
-
-        mNoDltContextData.buffer.str("");
-        mNoDltContextData.buffer.clear();
-    }
-
-    pthread_mutex_unlock(&mMutex);
-}
-
-void CAmDltWrapper::append(const int8_t value)
-{
-    if (mlogDestination == logDestination::DAEMON)
-    {
-        dlt_user_log_write_int8(&mDltContextData, value);
-    }
-    else
-    {
-        appendNoDLT(value);
-    }
-}
-
-void CAmDltWrapper::append(const uint8_t value)
-{
-    if (mlogDestination == logDestination::DAEMON)
-    {
-        dlt_user_log_write_uint8(&mDltContextData, value);
-    }
-    else
-    {
-        appendNoDLT(value);
-    }
-}
-
-void CAmDltWrapper::append(const int16_t value)
-{
-    if (mlogDestination == logDestination::DAEMON)
-    {
-        dlt_user_log_write_int16(&mDltContextData, value);
-    }
-    else
-    {
-        appendNoDLT(value);
-    }
-}
-
-void CAmDltWrapper::append(const uint16_t value)
-{
-    if (mlogDestination == logDestination::DAEMON)
-    {
-        dlt_user_log_write_uint16(&mDltContextData, value);
-    }
-    else
-    {
-        appendNoDLT(value);
-    }
-}
-
-void CAmDltWrapper::append(const int32_t value)
-{
-    if (mlogDestination == logDestination::DAEMON)
-    {
-        dlt_user_log_write_int32(&mDltContextData, value);
-    }
-    else
-    {
-        appendNoDLT(value);
-    }
-}
-
-void CAmDltWrapper::append(const uint32_t value)
-{
-    if (mlogDestination == logDestination::DAEMON)
-    {
-        dlt_user_log_write_uint32(&mDltContextData, value);
-    }
-    else
-    {
-        appendNoDLT(value);
-    }
-}
-
-void CAmDltWrapper::append(const std::string &value)
-{
-    append(value.c_str());
-}
-
-void CAmDltWrapper::append(const bool value)
-{
-    if (mlogDestination == logDestination::DAEMON)
-    {
-        dlt_user_log_write_bool(&mDltContextData, static_cast<uint8_t>(value));
-    }
-    else
-    {
-        appendNoDLT(value);
-    }
-}
-
-void CAmDltWrapper::append(const int64_t value)
-{
-    if (mlogDestination == logDestination::DAEMON)
-    {
-        dlt_user_log_write_int64(&mDltContextData, value);
-    }
-    else
-    {
-        appendNoDLT(value);
-    }
-}
-
-void CAmDltWrapper::append(const uint64_t value)
-{
-    if (mlogDestination == logDestination::DAEMON)
-    {
-        dlt_user_log_write_uint64(&mDltContextData, value);
-    }
-    else
-    {
-        appendNoDLT(value);
-    }
-}
-
-void CAmDltWrapper::append(const std::vector<uint8_t> &data)
-{
-    if (mlogDestination == logDestination::DAEMON)
-    {
-        dlt_user_log_write_raw(&mDltContextData, (void *)data.data(), data.size());
-    }
-    else
-    {
-        mNoDltContextData.buffer << data.data();
-    }
+    mpCurrentContext = NULL;
 }
 
 }
-#else // ------------------------------------------------------------------------------------------------- no DLT !
-CAmDltWrapper::CAmDltWrapper(const char *appid, const char *description, const bool debugEnabled, const logDestination logDest, const std::string Filename, bool onlyError)
-    : mDebugEnabled(debugEnabled)
-    ,                                //
-    mlogDestination(logDest)
-    ,                             //
-    mFilename(NULL)
-    ,                    //
-    mOnlyError(onlyError)
-    ,                          //
-    mLogOn(true)
-{
-    if (logDest == logDestination::DAEMON)
-    {
-        std::cout << "\033[0;31m[DLT] Cannot Use Daemon Logging, active in CMAKE! Using CommandLine\033[0m" << std::endl;
-        mlogDestination = logDestination::COMMAND_LINE;
-    }
-
-    if (mDebugEnabled)
-    {
-        if (mlogDestination == logDestination::COMMAND_LINE)
-        {
-            std::cout << "\033[0;36m[DLT] Registering AppID " << appid << " , " << description << "\033[0m" << std::endl;
-        }
-        else
-        {
-            mFilename.open(Filename, std::ofstream::out | std::ofstream::trunc);
-            if (!mFilename.is_open())
-            {
-                throw std::runtime_error("Cannot open file for logging");
-            }
-
-            mFilename << now() << "[DLT] Registering AppID " << appid << " , " << description << std::endl;
-        }
-    }
-}
-
-CAmDltWrapper::~CAmDltWrapper()
-{
-    if (mpDLTWrapper && mDebugEnabled && mlogDestination == logDestination::COMMAND_LINE)
-    {
-        mFilename.close();
-    }
-}
-
-void CAmDltWrapper::unregisterContext(DltContext &handle)
-{
-}
-
-void CAmDltWrapper::deinit()
-{
-}
-
-void CAmDltWrapper::registerContext(DltContext &handle, const char *contextid, const char *description)
-{
-    if (mDebugEnabled)
-    {
-        mMapContext.emplace(&handle, std::string(contextid));
-
-        if (mlogDestination == logDestination::COMMAND_LINE)
-        {
-            std::cout << "\033[0;36m[DLT] Registering Context " << contextid << " , " << description << "\033[0m" << std::endl;
-        }
-        else
-        {
-            mFilename << now() << "[DLT] Registering Context " << contextid << " , " << description << std::endl;
-        }
-    }
-}
-
-void CAmDltWrapper::registerContext(DltContext &handle, const char *contextid, const char *description, const DltLogLevelType level, const DltTraceStatusType status)
-{
-    if (mDebugEnabled)
-    {
-        mMapContext.emplace(&handle, std::string(contextid));
-
-        if (mlogDestination == logDestination::COMMAND_LINE)
-        {
-            std::cout << "\033[0;36m[DLT] Registering Context " << contextid << " , " << description << "\033[0m" << std::endl;
-        }
-        else
-        {
-            mFilename << now() << " [DLT] Registering Context " << contextid << " , " << description << std::endl;
-        }
-    }
-}
-
-bool CAmDltWrapper::init(DltLogLevelType loglevel, DltContext *context)
-{
-    pthread_mutex_lock(&mMutex);
-    return initNoDlt(loglevel, context);
-}
-
-void CAmDltWrapper::send()
-{
-    if (mlogDestination == logDestination::COMMAND_LINE && mLogOn)
-    {
-        std::cout << mNoDltContextData.buffer.str().c_str() << std::endl;
-    }
-    else if (mLogOn)
-    {
-        mFilename << now() << mNoDltContextData.buffer.str().c_str() << std::endl;
-    }
-
-    mNoDltContextData.buffer.str("");
-    mNoDltContextData.buffer.clear();
-    pthread_mutex_unlock(&mMutex);
-}
-
-void CAmDltWrapper::append(const int8_t value)
-{
-    appendNoDLT(value);
-}
-
-void CAmDltWrapper::append(const uint8_t value)
-{
-    appendNoDLT(value);
-}
-
-void CAmDltWrapper::append(const int16_t value)
-{
-    appendNoDLT(value);
-}
-
-void CAmDltWrapper::append(const uint16_t value)
-{
-    appendNoDLT(value);
-}
-
-void CAmDltWrapper::append(const int32_t value)
-{
-    appendNoDLT(value);
-}
-
-void CAmDltWrapper::append(const uint32_t value)
-{
-    appendNoDLT(value);
-}
-
-void CAmDltWrapper::append(const std::string &value)
-{
-    append(value.c_str());
-}
-
-void CAmDltWrapper::append(const bool value)
-{
-    appendNoDLT(value);
-}
-
-void CAmDltWrapper::append(const int64_t value)
-{
-    appendNoDLT(value);
-}
-
-void CAmDltWrapper::append(const uint64_t value)
-{
-    appendNoDLT(value);
-}
-
-void CAmDltWrapper::append(const std::vector<uint8_t> &data)
-{
-    mNoDltContextData.buffer << data.data();
-}
-
-}
-#endif // WITH_DLT

--- a/AudioManagerUtilities/src/CAmLogWrapper.cpp
+++ b/AudioManagerUtilities/src/CAmLogWrapper.cpp
@@ -1,0 +1,125 @@
+/**
+ * SPDX license identifier: MPL-2.0
+ *
+ * Copyright (C) 2017, ADIT GmbH
+ *
+ * This file is part of GENIVI Project AudioManager.
+ *
+ * Contributions are licensed to the GENIVI Alliance under one or more
+ * Contribution License Agreements.
+ *
+ * \copyright
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a  copy of the MPL was not distributed with
+ * this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *
+ * \author Mattia Guerra, mguerra@de.adit-jv.com ADIT 2017
+ * \author Jens Lorenz, jlorenz@de.adit-jv.com ADIT 2017
+ *
+ * \file CAmLogWrapper.cpp
+ * For further information see http://www.genivi.org/.
+ *
+ */
+
+#include <iostream>
+#include <unistd.h>
+#include "CAmLogWrapper.h"
+#include "CAmLoggerStdOut.h"
+#include "CAmLoggerFile.h"
+#ifdef WITH_DLT
+# include "CAmLoggerDlt.h"
+#endif
+
+
+using namespace std;
+
+namespace am
+{
+
+IAmLogger      *CAmLogWrapper::mpLogger     = NULL;
+string          CAmLogWrapper::mAppId       = "";
+string          CAmLogWrapper::mDescription = "";
+am_LogStatus_e  CAmLogWrapper::mLogStatus   = LS_ON;
+am_LogService_e CAmLogWrapper::mLogService  = DEFAULT_LOG_SERVICE;
+string          CAmLogWrapper::mFilename    = "";
+bool            CAmLogWrapper::mOnlyError   = false;
+
+CAmLogWrapper::CAmLogWrapper(void)
+{
+}
+
+IAmLogger *CAmLogWrapper::instantiateOnce(const char *appid, const char *description,
+    const am_LogStatus_e logStatus, const am_LogService_e logService,
+    const string fileName, bool onlyError)
+{
+    if (mpLogger)
+    {
+        return mpLogger;
+    }
+
+    mAppId       = string(appid);
+    mDescription = string(description);
+    mLogStatus   = logStatus;
+    mLogService  = logService;
+    mFilename    = fileName;
+    mOnlyError   = onlyError;
+    return instance(mLogService);
+}
+
+IAmLogger *CAmLogWrapper::instance(const am_LogService_e service)
+{
+    if (mpLogger)
+    {
+        return mpLogger;
+    }
+
+    switch (service)
+    {
+    case LOG_SERVICE_DLT:
+#ifdef WITH_DLT
+        mpLogger = new CAmLoggerDlt();
+#else
+        std::cerr << "Option WITH_DLT not enabled for CAmLogWrapper! "
+                  << "Redirecting log output to stdout ..." << std::endl;
+        mLogService = LOG_SERVICE_STDOUT;
+        mpLogger = new CAmLoggerStdOut(mLogStatus, mOnlyError);
+#endif
+        break;
+    case LOG_SERVICE_STDOUT:
+        mpLogger = new CAmLoggerStdOut(mLogStatus, mOnlyError);
+        break;
+    case LOG_SERVICE_FILE:
+        mpLogger = new CAmLoggerFile(mLogStatus, mOnlyError, mFilename);
+        break;
+    default:
+        mpLogger = new CAmLoggerStdOut(LS_OFF);
+        break;
+    }
+
+    // an application seems not to use our CAmLogWrapper class properly therefore create default context
+    if ((mLogStatus == LS_ON) && mAppId.empty() && mDescription.empty())
+    {
+        mAppId = "AMDL";
+        std::ostringstream description;
+        description << "PID=" << getpid() << " _=" << getenv("_");
+        mDescription = description.str().c_str();
+        std::cerr << "Application doesn't call CAmLogWrapper::instantiateOnce!!!" << std::endl;
+        std::cerr << "-> CAmLogWrapper::instance registers DLT application [ AMDL | " << description.str() << " ]" << std::endl;
+    }
+
+    mpLogger->registerApp(mAppId.c_str(), mDescription.c_str());
+
+    return mpLogger;
+}
+
+CAmLogWrapper::~CAmLogWrapper()
+{
+    if (mpLogger)
+    {
+        mpLogger->unregisterApp();
+        delete mpLogger;
+    }
+}
+
+}

--- a/AudioManagerUtilities/src/CAmLoggerDlt.cpp
+++ b/AudioManagerUtilities/src/CAmLoggerDlt.cpp
@@ -1,0 +1,223 @@
+/**
+ * SPDX license identifier: MPL-2.0
+ *
+ * Copyright (C) 2015, ADIT GmbH
+ *
+ * This file is part of GENIVI Project AudioManager.
+ *
+ * Contributions are licensed to the GENIVI Alliance under one or more
+ * Contribution License Agreements.
+ *
+ * \copyright
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a  copy of the MPL was not distributed with
+ * this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *
+ * \author Jens Lorenz, jlorenz@de.adit-jv.com ADIT 2017
+ * \author Mattia Guerra, mguerra@de.adit-jv.com ADIT 2017
+ * \author Martin Koch, mkoch@de.adit-jv.com ADIT 2020
+ *
+ * \file CAmLoggerDlt.cpp
+ * For further information see http://www.genivi.org/.
+ *
+ */
+
+#include "CAmLogWrapper.h"
+#include "CAmLoggerDlt.h"
+
+namespace am
+{
+
+pthread_mutex_t gDltMtx = PTHREAD_MUTEX_INITIALIZER;
+
+CAmLogContextDlt::CAmLogContextDlt(const char *id)
+    : mId(id)
+{
+}
+
+DltContext *CAmLogContextDlt::getHandle()
+{
+    return &mDltContext;
+}
+
+void CAmLogContextDlt::append(const int8_t value)
+{
+    dlt_user_log_write_int8(&mDltContextData, value);
+}
+
+void CAmLogContextDlt::append(const uint8_t value)
+{
+    dlt_user_log_write_uint8(&mDltContextData, value);
+}
+
+void CAmLogContextDlt::append(const int16_t value)
+{
+    dlt_user_log_write_int16(&mDltContextData, value);
+}
+
+void CAmLogContextDlt::append(const uint16_t value)
+{
+    dlt_user_log_write_uint16(&mDltContextData, value);
+}
+
+void CAmLogContextDlt::append(const int32_t value)
+{
+    dlt_user_log_write_int32(&mDltContextData, value);
+}
+
+void CAmLogContextDlt::append(const uint32_t value)
+{
+    dlt_user_log_write_uint32(&mDltContextData, value);
+}
+
+void CAmLogContextDlt::append(const bool value)
+{
+    dlt_user_log_write_bool(&mDltContextData, static_cast<uint8_t>(value));
+}
+
+void CAmLogContextDlt::append(const int64_t value)
+{
+    dlt_user_log_write_int64(&mDltContextData, value);
+}
+
+void CAmLogContextDlt::append(const uint64_t value)
+{
+    dlt_user_log_write_uint64(&mDltContextData, value);
+}
+
+void CAmLogContextDlt::append(const std::vector<uint8_t> &data)
+{
+    dlt_user_log_write_raw(&mDltContextData, (void *)data.data(), data.size());
+}
+
+void CAmLogContextDlt::append(const char *value)
+{
+    dlt_user_log_write_string(&mDltContextData, value);
+}
+
+bool CAmLogContextDlt::checkLogLevel(const am_LogLevel_e logLevel)
+{
+#ifdef DLT_IS_LOG_LEVEL_ENABLED
+    return (dlt_user_is_logLevel_enabled(&mDltContext, static_cast<DltLogLevelType>(logLevel)) == DLT_RETURN_TRUE);
+#else
+    (void)logLevel;
+    return true;
+#endif
+}
+
+bool CAmLogContextDlt::configure(const am_LogLevel_e loglevel)
+{
+    pthread_mutex_lock(&gDltMtx);
+
+    /* leave in case we are allowed to send messages */
+    if (dlt_user_log_write_start(&mDltContext, &mDltContextData, static_cast<DltLogLevelType>(loglevel)) > 0)
+    {
+        return true;
+    }
+
+    pthread_mutex_unlock(&gDltMtx);
+    return false;
+}
+
+void CAmLogContextDlt::send()
+{
+    dlt_user_log_write_finish(&mDltContextData);
+    pthread_mutex_unlock(&gDltMtx);
+}
+
+CAmLoggerDlt::~CAmLoggerDlt()
+{
+    unregisterApp();
+}
+
+void CAmLoggerDlt::registerApp(const char *appid, const char *description)
+{
+    dlt_register_app(appid, description);
+    registerContext(DEFAULT_CONTEXT, DEFAULT_DESCRIPTION);
+}
+
+void CAmLoggerDlt::unregisterApp()
+{
+    for (auto &&context : mCtxTable)
+    {
+        dlt_unregister_context(context.second->getHandle());
+        delete context.second;
+        delete context.first;
+    }
+    mCtxTable.clear();
+
+    dlt_unregister_app();
+}
+
+IAmLogContext &CAmLoggerDlt::registerContext(const char *contextid, const char *description)
+{
+    auto &&context = createContext(contextid);
+    dlt_register_context(context.getHandle(), contextid, description);
+    return context;
+}
+
+IAmLogContext &CAmLoggerDlt::registerContext(const char *contextid, const char *description, const am_LogLevel_e level, const am_LogStatus_e status)
+{
+    auto &&context = createContext(contextid);
+    dlt_register_context_ll_ts(context.getHandle(), contextid, description, static_cast<DltLogLevelType>(level), static_cast<DltTraceStatusType>(status));
+    return context;
+}
+
+IAmLogContext &CAmLoggerDlt::importContext(const char *contextid)
+{
+    // check, if we have this context
+    contextid = (contextid ? contextid : DEFAULT_CONTEXT);
+    for (auto &ctx : mCtxTable)
+    {
+        if (contextid && strncmp(ctx.first, contextid, DLT_ID_SIZE) == 0)
+        {
+            return *ctx.second;
+        }
+    }
+
+    // no match. Fall back to default context
+    return importContext(DEFAULT_CONTEXT);
+}
+
+void CAmLoggerDlt::unregisterContext(const char *contextid)
+{
+    for (auto it = mCtxTable.begin(); it != mCtxTable.end(); ++it)
+    {
+        if (contextid && strncmp(contextid, it->first, DLT_ID_SIZE) == 0)
+        {
+            dlt_unregister_context(it->second->getHandle());
+            delete it->second;
+
+            const char *pKey = it->first;
+            mCtxTable.erase(it);
+            delete pKey;
+
+            return;
+        }
+    }
+}
+
+CAmLogContextDlt &CAmLoggerDlt::createContext(const char *contextid)
+{
+    // check, if we already have this context
+    for (auto &ctx : mCtxTable)
+    {
+        if (contextid && strncmp(contextid, ctx.first, DLT_ID_SIZE) == 0)
+        {
+            return *ctx.second;
+        }
+    }
+
+    // Not in list. Create new
+    size_t len = (contextid ? strlen(contextid) : 0);
+    char *pKey = new char[1 + len];
+    strncpy(pKey, contextid, len);
+    pKey[len] = '\0';
+    auto *pContext = new CAmLogContextDlt(contextid);
+    mCtxTable[pKey] = pContext;
+
+    return *pContext;
+}
+
+}

--- a/AudioManagerUtilities/src/CAmLoggerFile.cpp
+++ b/AudioManagerUtilities/src/CAmLoggerFile.cpp
@@ -1,0 +1,252 @@
+/**
+ * SPDX license identifier: MPL-2.0
+ *
+ * Copyright (C) 2017, ADIT GmbH
+ *
+ * This file is part of GENIVI Project AudioManager.
+ *
+ * Contributions are licensed to the GENIVI Alliance under one or more
+ * Contribution License Agreements.
+ *
+ * \copyright
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a  copy of the MPL was not distributed with
+ * this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * \author Jens Lorenz, jlorenz@de.adit-jv.com ADIT 2017
+ * \author Mattia Guerra, mguerra@de.adit-jv.com ADIT 2017
+ * \author Martin Koch, mkoch@de.adit-jv.com ADIT 2020
+ *
+ * \file CAmLoggerFile.cpp
+ * For further information see http://www.genivi.org/.
+ *
+ */
+
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+#include <mutex>
+#include <iomanip>
+#include "CAmLogWrapper.h"
+#include "CAmLoggerFile.h"
+#include "CAmTimeUtility.h"
+
+using namespace std;
+
+namespace am
+{
+
+#define PADDING_WIDTH 4
+
+pthread_mutex_t gFileMtx = PTHREAD_MUTEX_INITIALIZER;
+
+ostream &operator <<(ostream &out, const class CFileHeader &h)
+{
+    out << CAmTimeUtility::now() << "[" << setw(PADDING_WIDTH) << left << string(h.mCtx, 0, PADDING_WIDTH) << "] ";
+    return out;
+}
+
+CAmLogContextFile::CAmLogContextFile(const char *id, const am_LogLevel_e level, const am_LogStatus_e status, ofstream &filestream)
+    : mHeader(id)
+    , mLogLevel(level)
+    , mLogStatus(status)
+    , mFilestream(filestream)
+{
+}
+
+void CAmLogContextFile::append(const int8_t value)
+{
+    appendFile(value);
+}
+
+void CAmLogContextFile::append(const uint8_t value)
+{
+    appendFile(value);
+}
+
+void CAmLogContextFile::append(const int16_t value)
+{
+    appendFile(value);
+}
+
+void CAmLogContextFile::append(const uint16_t value)
+{
+    appendFile(value);
+}
+
+void CAmLogContextFile::append(const int32_t value)
+{
+    appendFile(value);
+}
+
+void CAmLogContextFile::append(const uint32_t value)
+{
+    appendFile(value);
+}
+
+void CAmLogContextFile::append(const uint64_t value)
+{
+    appendFile(value);
+}
+
+void CAmLogContextFile::append(const int64_t value)
+{
+    appendFile(value);
+}
+
+void CAmLogContextFile::append(const bool value)
+{
+    appendFile(value);
+}
+
+void CAmLogContextFile::append(const char *value)
+{
+    appendFile(value);
+}
+
+void CAmLogContextFile::append(const vector<uint8_t> &data)
+{
+    mFilestream << data.data() << " ";
+}
+
+template<class T>
+void CAmLogContextFile::appendFile(T value)
+{
+    mFilestream << value << " ";
+}
+
+bool CAmLogContextFile::configure(const am_LogLevel_e loglevel)
+{
+    if (LS_OFF || loglevel > mLogLevel)
+    {
+        return false;
+    }
+
+    pthread_mutex_lock(&gFileMtx);
+    mFilestream << mHeader;
+
+    return true;
+}
+
+bool CAmLogContextFile::checkLogLevel(const am_LogLevel_e logLevel)
+{
+    return logLevel <= mLogLevel;
+}
+
+void CAmLogContextFile::send()
+{
+    mFilestream << endl;
+    pthread_mutex_unlock(&gFileMtx);
+}
+
+CAmLoggerFile::CAmLoggerFile(const am_LogStatus_e status, const bool onlyError, const string &filename)
+    : mLogStatus(status)
+    , mStandardLogLevel(onlyError ? LL_ERROR : LL_INFO)
+{
+    if (mLogStatus == LS_OFF)
+    {
+        cout << "Running without Logging support" << endl;
+        return;
+    }
+
+    mFilestream.open(filename.c_str(), ofstream::out | ofstream::trunc);
+    if (!mFilestream.is_open())
+    {
+        throw runtime_error("Cannot open log file: " + filename);
+    }
+}
+
+CAmLoggerFile::~CAmLoggerFile()
+{
+    mFilestream.close();
+    unregisterApp();
+}
+
+void CAmLoggerFile::unregisterApp()
+{
+    for (auto &&context : mCtxTable)
+    {
+        unregisterContext(context.first);
+    }
+}
+
+void CAmLoggerFile::registerApp(const char *appid, const char *description)
+{
+    if (mLogStatus == LS_ON)
+    {
+        mFilestream << mHeader << "Register Application " << string(appid, PADDING_WIDTH) << ", " << description << endl;
+    }
+
+    registerContext(DEFAULT_CONTEXT, DEFAULT_DESCRIPTION);
+}
+
+IAmLogContext &CAmLoggerFile::registerContext(const char *contextid, const char *description)
+{
+    return registerContext(contextid, description, mStandardLogLevel, mLogStatus);
+}
+
+IAmLogContext &CAmLoggerFile::registerContext(const char *contextid, const char *description,
+    const am_LogLevel_e level, const am_LogStatus_e status)
+{
+    // check, if we already have this context
+    for (auto &ctx : mCtxTable)
+    {
+        if (contextid && strncmp(contextid, ctx.first, PADDING_WIDTH) == 0)
+        {
+            return *ctx.second;
+        }
+    }
+
+    // Not in list. Create new
+    if (mLogStatus == LS_ON)
+    {
+        mFilestream << mHeader << "Registering Context " << string(contextid, PADDING_WIDTH) << ", " << description << endl;
+    }
+    size_t len = (contextid ? strlen(contextid) : 0);
+    char *pKey = new char[1 + len];
+    strncpy(pKey, contextid, len);
+    pKey[len] = '\0';
+    auto *pContext = new CAmLogContextFile(contextid, level, status, mFilestream);
+    mCtxTable[pKey] = pContext;
+
+    return *pContext;
+}
+
+IAmLogContext &CAmLoggerFile::importContext(const char *contextid)
+{
+    // check, if we have this context
+    contextid = (contextid ? contextid : DEFAULT_CONTEXT);
+    for (auto &ctx : mCtxTable)
+    {
+        if (contextid && strncmp(ctx.first, contextid, PADDING_WIDTH) == 0)
+        {
+            return *ctx.second;
+        }
+    }
+
+    // no match. Fall back to default context
+    return importContext(DEFAULT_CONTEXT);
+}
+
+void CAmLoggerFile::unregisterContext(const char *contextid)
+{
+    for (auto it = mCtxTable.begin(); it != mCtxTable.end(); ++it)
+    {
+        if (contextid && strncmp(contextid, it->first, PADDING_WIDTH) == 0)
+        {
+            delete it->second;
+            const char *key = it->first;
+            mCtxTable.erase(it);
+            delete key;
+
+            if (mLogStatus == LS_ON)
+            {
+                mFilestream << mHeader << "Context " << string(contextid, PADDING_WIDTH) << "unregistered" << endl;
+            }
+
+            return;
+        }
+    }
+}
+
+}

--- a/AudioManagerUtilities/src/CAmLoggerStdOut.cpp
+++ b/AudioManagerUtilities/src/CAmLoggerStdOut.cpp
@@ -1,0 +1,264 @@
+/**
+ * SPDX license identifier: MPL-2.0
+ *
+ * Copyright (C) 2017, ADIT GmbH
+ *
+ * This file is part of GENIVI Project AudioManager.
+ *
+ * Contributions are licensed to the GENIVI Alliance under one or more
+ * Contribution License Agreements.
+ *
+ * \copyright
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a  copy of the MPL was not distributed with
+ * this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * \author Jens Lorenz, jlorenz@de.adit-jv.com ADIT 2017
+ * \author Mattia Guerra, mguerra@de.adit-jv.com ADIT 2017
+ * \author Martin Koch, mkoch@de.adit-jv.com ADIT 2020
+ *
+ * \file CAmLoggerStdOut.cpp
+ * For further information see http://www.genivi.org/.
+ *
+ */
+
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+#include <mutex>
+#include <iomanip>
+#include "CAmLogWrapper.h"
+#include "CAmLoggerStdOut.h"
+#include "CAmTimeUtility.h"
+
+using namespace std;
+
+namespace am
+{
+
+#define PADDING_WIDTH 4
+
+pthread_mutex_t gStdOutMtx = PTHREAD_MUTEX_INITIALIZER;
+
+ostream &operator <<(ostream &out, const class CStdOutHeader &h)
+{
+    out << CAmTimeUtility::now() << h.mCc << "[" << setw(PADDING_WIDTH) << left << string(h.mCtx, 0, PADDING_WIDTH) << "] " << CC_RESET;
+    return out;
+}
+
+CAmLogContextStdOut::CAmLogContextStdOut(const char *id, const am_LogLevel_e level, const am_LogStatus_e status)
+    : mHeader(id, CC_GREEN)
+    , mLogLevel(level)
+    , mLogStatus(status)
+{
+}
+
+void CAmLogContextStdOut::changeLogLS(const am_LogLevel_e level, const am_LogStatus_e status)
+{
+    mLogLevel  = level;
+    mLogStatus = status;
+}
+
+void CAmLogContextStdOut::append(const int8_t value)
+{
+    appendStdOut(value);
+}
+
+void CAmLogContextStdOut::append(const uint8_t value)
+{
+    appendStdOut(value);
+}
+
+void CAmLogContextStdOut::append(const int16_t value)
+{
+    appendStdOut(value);
+}
+
+void CAmLogContextStdOut::append(const uint16_t value)
+{
+    appendStdOut(value);
+}
+
+void CAmLogContextStdOut::append(const int32_t value)
+{
+    appendStdOut(value);
+}
+
+void CAmLogContextStdOut::append(const uint32_t value)
+{
+    appendStdOut(value);
+}
+
+void CAmLogContextStdOut::append(const uint64_t value)
+{
+    appendStdOut(value);
+}
+
+void CAmLogContextStdOut::append(const int64_t value)
+{
+    appendStdOut(value);
+}
+
+void CAmLogContextStdOut::append(const bool value)
+{
+    appendStdOut(value);
+}
+
+void CAmLogContextStdOut::append(const char *value)
+{
+    appendStdOut(value);
+}
+
+void CAmLogContextStdOut::append(const vector<uint8_t> &data)
+{
+    cout << data.data() << " ";
+}
+
+template<class T>
+void CAmLogContextStdOut::appendStdOut(T value)
+{
+    cout << value << " ";
+}
+
+bool CAmLogContextStdOut::configure(const am_LogLevel_e loglevel)
+{
+    if ((mLogStatus == LS_OFF) || (loglevel > mLogLevel))
+    {
+        return false;
+    }
+
+    pthread_mutex_lock(&gStdOutMtx);
+
+    switch (loglevel)
+    {
+    case LL_ERROR:
+        cout << mHeader << CC_RED;
+        break;
+    case LL_WARN:
+        cout << mHeader << CC_YELLOW;
+        break;
+    default:
+        cout << mHeader << CC_RESET;
+        break;
+    }
+
+    return true;
+}
+
+bool CAmLogContextStdOut::checkLogLevel(const am_LogLevel_e logLevel)
+{
+    return ((mLogStatus == LS_ON) && (logLevel <= mLogLevel));
+}
+
+void CAmLogContextStdOut::send()
+{
+    // NOTE: The color is set in the configure function
+    cout << CC_RESET << endl;
+    pthread_mutex_unlock(&gStdOutMtx);
+}
+
+CAmLoggerStdOut::CAmLoggerStdOut(const am_LogStatus_e status, const bool onlyError)
+    : mLogStatus(status)
+    , mStandardLogLevel(onlyError ? LL_ERROR : LL_INFO)
+{
+    if (mLogStatus == LS_OFF)
+    {
+        cout << mHeader << "Running without Logging support" << endl;
+    }
+}
+
+CAmLoggerStdOut::~CAmLoggerStdOut()
+{
+    unregisterApp();
+}
+
+void CAmLoggerStdOut::unregisterApp()
+{
+    for (auto &&context : mCtxTable)
+    {
+        unregisterContext(context.first);
+    }
+}
+
+void CAmLoggerStdOut::registerApp(const char *appid, const char *description)
+{
+    if (mLogStatus == LS_ON)
+    {
+        cout << mHeader << "Register Application " << string(appid, PADDING_WIDTH) << ", " << description << endl;
+    }
+
+    registerContext(DEFAULT_CONTEXT, DEFAULT_DESCRIPTION);
+}
+
+IAmLogContext &CAmLoggerStdOut::registerContext(const char *contextid, const char *description)
+{
+    return registerContext(contextid, description, mStandardLogLevel, mLogStatus);
+}
+
+IAmLogContext &CAmLoggerStdOut::registerContext(const char *contextid, const char *description,
+    const am_LogLevel_e level, const am_LogStatus_e status)
+{
+    // check, if we already have this context
+    for (auto &ctx : mCtxTable)
+    {
+        if (contextid && strncmp(contextid, ctx.first, PADDING_WIDTH) == 0)
+        {
+            ctx.second->changeLogLS(level, status);
+            return *ctx.second;
+        }
+    }
+
+    // Not in list. Create new
+    if (mLogStatus == LS_ON)
+    {
+        cout << mHeader << "Registering Context " << string(contextid, PADDING_WIDTH) << ", " << description << endl;
+    }
+    size_t len = (contextid ? strlen(contextid) : 0);
+    char *pKey = new char[1 + len];
+    strncpy(pKey, contextid, len);
+    pKey[len] = '\0';
+    auto *pContext = new CAmLogContextStdOut(contextid, level, status);
+    pContext->changeLogLS(level, status);
+    mCtxTable[pKey] = pContext;
+
+    return *pContext;
+}
+
+IAmLogContext &CAmLoggerStdOut::importContext(const char *contextid)
+{
+    // check, if we have this context
+    contextid = (contextid ? contextid : DEFAULT_CONTEXT);
+    for (auto &ctx : mCtxTable)
+    {
+        if (contextid && strncmp(ctx.first, contextid, PADDING_WIDTH) == 0)
+        {
+            return *ctx.second;
+        }
+    }
+
+    // no match. Fall back to default context
+    return importContext(DEFAULT_CONTEXT);
+}
+
+void CAmLoggerStdOut::unregisterContext(const char *contextid)
+{
+    for (auto it = mCtxTable.begin(); it != mCtxTable.end(); ++it)
+    {
+        if (contextid && strncmp(contextid, it->first, PADDING_WIDTH) == 0)
+        {
+            delete it->second;
+            const char *key = it->first;
+            mCtxTable.erase(it);
+            delete key;
+
+            if (mLogStatus == LS_ON)
+            {
+                cout << mHeader << string(contextid, PADDING_WIDTH) << " unregistered" << endl;
+            }
+
+            return;
+        }
+    }
+}
+
+}

--- a/AudioManagerUtilities/src/CAmSocketHandler.cpp
+++ b/AudioManagerUtilities/src/CAmSocketHandler.cpp
@@ -33,7 +33,7 @@
 #include <csignal>
 #include <cstring>
 
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 #include "CAmSocketHandler.h"
 
 #ifdef WITH_TIMERFD

--- a/AudioManagerUtilities/src/CAmWatchdog.cpp
+++ b/AudioManagerUtilities/src/CAmWatchdog.cpp
@@ -26,7 +26,7 @@
 #include <cstdlib>
 #include <stdexcept>
 #include "audiomanagerconfig.h"
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 #include <systemd/sd-daemon.h>
 
 namespace am

--- a/AudioManagerUtilities/test/AmSocketHandlerTest/CAmSocketHandlerTest.cpp
+++ b/AudioManagerUtilities/test/AmSocketHandlerTest/CAmSocketHandlerTest.cpp
@@ -32,7 +32,7 @@
 #include <sys/un.h>
 #include <sys/poll.h>
 #include <sys/eventfd.h>
-#include "CAmDltWrapper.h"
+#include "CAmLogWrapper.h"
 #include "CAmSocketHandler.h"
 
 
@@ -771,6 +771,7 @@ TEST(CAmSocketHandlerTest,playWithSockets)
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
+    CAmLogWrapper::instantiateOnce("GTST", "GTEST for Socket Handler", LS_ON, LOG_SERVICE_DLT);
     return RUN_ALL_TESTS();
 }
 

--- a/AudioManagerUtilities/test/CMakeLists.txt
+++ b/AudioManagerUtilities/test/CMakeLists.txt
@@ -1,2 +1,8 @@
-add_subdirectory (AmSocketHandlerTest)
+if (WITH_DLT)
+    # this test works only if Utilities are built with DLT support - skip otherwise
+    add_subdirectory (AmSocketHandlerTest)
+else (WITH_DLT)
+    message ( WARNING "CAmSocketHandlerTest requires DLT support - skipping ...")
+endif (WITH_DLT)
+
 add_subdirectory (AmSerializerTest)

--- a/Foo/uncrustify_files.cfg
+++ b/Foo/uncrustify_files.cfg
@@ -1,5 +1,9 @@
 ./AudioManagerUtilities/src/CAmCommonAPIWrapper.cpp
 ./AudioManagerUtilities/src/CAmDltWrapper.cpp
+./AudioManagerUtilities/src/CAmLogWrapper.cpp
+./AudioManagerUtilities/src/CAmLoggerDlt.cpp
+./AudioManagerUtilities/src/CAmLoggerFile.cpp
+./AudioManagerUtilities/src/CAmLoggerStdOut.cpp
 ./AudioManagerUtilities/src/CAmSocketHandler.cpp
 ./AudioManagerUtilities/src/CAmDbusWrapper.cpp
 ./AudioManagerUtilities/src/CAmCommandLineSingleton.cpp
@@ -18,6 +22,12 @@
 ./AudioManagerUtilities/include/CAmDbusWrapper.h
 ./AudioManagerUtilities/include/CAmSerializer.h
 ./AudioManagerUtilities/include/CAmDltWrapper.h
+./AudioManagerUtilities/include/IAmLogger.h
+./AudioManagerUtilities/include/CAmLogWrapper.h
+./AudioManagerUtilities/include/CAmTimeUtility.h
+./AudioManagerUtilities/include/CAmLoggerDlt.h
+./AudioManagerUtilities/include/CAmLoggerFile.h
+./AudioManagerUtilities/include/CAmLoggerStdOut.h
 ./AudioManagerUtilities/include/CAmWatchdog.h
 ./AudioManagerUtilities/include/TAmPluginTemplate.h
 ./AudioManagerUtilities/include/CAmCommandLineSingleton.h


### PR DESCRIPTION
Introduce new logging architecture consisting of a common wrapper class
-	CAmLogWrapper, which hosts channel-specific logger classes
o	CAmLoggerDlt
o	CAmLoggerFile and
o	CAmLoggerStdOut, all implementing the interface specified in
o	IAmLogger
This approach encapsulates the specifics of each output channel into separate files. Especially the availability of the DLT functionality no longer affects all components working with the logging utility. Instead, the library is either built with or without DLT support. There is no need to configure the compilation of the applications (plugins) identically.
Of cause, the old logging interface is retained for backward compatibility reason.

This requested change-set is split into 4 separate commits:
1.	Introduce the new classes side-by-side with the old mechanism
2.	convert the old class CAmDltWrapper to a pure legacy wrapper around the new architecture, but retain its public interface
3.	fix compilation issue in module test if WITH_DLT is OFF and WITH_TESTS is ON
4.	reorganize daemon, core, utilities and tests to make full use of the new logging architecture

We (hopefully) discuss this request at:
https://lists.genivi.org/mailman/listinfo/genivi-audio-manager_lists.genivi.org

