### PR TITLE
Plural properties

### DIFF
--- a/AudioManagerCore/include/CAmCommandReceiver.h
+++ b/AudioManagerCore/include/CAmCommandReceiver.h
@@ -49,7 +49,9 @@ public:
     am_Error_e volumeStep(const am_sinkID_t sinkID, const int16_t volumeStep);
     am_Error_e setSinkMuteState(const am_sinkID_t sinkID, const am_MuteState_e muteState);
     am_Error_e setMainSinkSoundProperty(const am_MainSoundProperty_s &soundProperty, const am_sinkID_t sinkID);
+    am_Error_e setMainSinkSoundProperties(const std::vector<am_MainSoundProperty_s> &listSoundProperties, const am_sinkID_t sinkID);
     am_Error_e setMainSourceSoundProperty(const am_MainSoundProperty_s &soundProperty, const am_sourceID_t sourceID);
+    am_Error_e setMainSourceSoundProperties(const std::vector<am_MainSoundProperty_s> &listSoundProperties, const am_sourceID_t sourceID);
     am_Error_e setSystemProperty(const am_SystemProperty_s &property);
     am_Error_e getVolume(const am_sinkID_t sinkID, am_mainVolume_t &mainVolume) const;
     am_Error_e getListMainConnections(std::vector<am_MainConnectionType_s> &listConnections) const;

--- a/AudioManagerCore/include/CAmCommandReceiver.h
+++ b/AudioManagerCore/include/CAmCommandReceiver.h
@@ -53,6 +53,7 @@ public:
     am_Error_e setMainSourceSoundProperty(const am_MainSoundProperty_s &soundProperty, const am_sourceID_t sourceID);
     am_Error_e setMainSourceSoundProperties(const std::vector<am_MainSoundProperty_s> &listSoundProperties, const am_sourceID_t sourceID);
     am_Error_e setSystemProperty(const am_SystemProperty_s &property);
+    am_Error_e setSystemProperties(const std::vector<am_SystemProperty_s> &listSystemProperties);
     am_Error_e getVolume(const am_sinkID_t sinkID, am_mainVolume_t &mainVolume) const;
     am_Error_e getListMainConnections(std::vector<am_MainConnectionType_s> &listConnections) const;
     am_Error_e getListMainSinks(std::vector<am_SinkType_s> &listMainSinks) const;

--- a/AudioManagerCore/include/CAmCommandSender.h
+++ b/AudioManagerCore/include/CAmCommandSender.h
@@ -60,7 +60,9 @@ public:
     void cbNumberOfSourceClassesChanged();
     void cbMainConnectionStateChanged(const am_mainConnectionID_t connectionID, const am_ConnectionState_e connectionState);
     void cbMainSinkSoundPropertyChanged(const am_sinkID_t sinkID, const am_MainSoundProperty_s &soundProperty);
+    void cbMainSinkSoundPropertiesChanged(const am_sinkID_t sinkID, const std::vector<am_MainSoundProperty_s> &listSoundProperties);
     void cbMainSourceSoundPropertyChanged(const am_sourceID_t sourceID, const am_MainSoundProperty_s &soundProperty);
+    void cbMainSourceSoundPropertiesChanged(const am_sourceID_t sourceID, const std::vector<am_MainSoundProperty_s> &listSoundProperties);
     void cbSinkAvailabilityChanged(const am_sinkID_t sinkID, const am_Availability_s &availability);
     void cbSourceAvailabilityChanged(const am_sourceID_t sourceID, const am_Availability_s &availability);
     void cbVolumeChanged(const am_sinkID_t sinkID, const am_mainVolume_t volume);

--- a/AudioManagerCore/include/CAmCommandSender.h
+++ b/AudioManagerCore/include/CAmCommandSender.h
@@ -68,6 +68,7 @@ public:
     void cbVolumeChanged(const am_sinkID_t sinkID, const am_mainVolume_t volume);
     void cbSinkMuteStateChanged(const am_sinkID_t sinkID, const am_MuteState_e muteState);
     void cbSystemPropertyChanged(const am_SystemProperty_s &systemProperty);
+    void cbSystemPropertiesChanged(const std::vector<am_SystemProperty_s> &listSystemProperties);
     void cbTimingInformationChanged(const am_mainConnectionID_t mainConnectionID, const am_timeSync_t time);
     void getInterfaceVersion(std::string &version) const;
     am_Error_e getListPlugins(std::vector<std::string> &interfaces) const;

--- a/AudioManagerCore/include/CAmControlReceiver.h
+++ b/AudioManagerCore/include/CAmControlReceiver.h
@@ -76,7 +76,9 @@ public:
     am_Error_e changDomainStateDB(const am_DomainState_e domainState, const am_domainID_t domainID);
     am_Error_e changeSinkMuteStateDB(const am_MuteState_e muteState, const am_sinkID_t sinkID);
     am_Error_e changeMainSinkSoundPropertyDB(const am_MainSoundProperty_s &soundProperty, const am_sinkID_t sinkID);
+    am_Error_e changeMainSinkSoundPropertiesDB(const std::vector<am_MainSoundProperty_s> &listSoundProperties, const am_sinkID_t sinkID);
     am_Error_e changeMainSourceSoundPropertyDB(const am_MainSoundProperty_s &soundProperty, const am_sourceID_t sourceID);
+    am_Error_e changeMainSourceSoundPropertiesDB(const std::vector<am_MainSoundProperty_s> &listSoundProperties, const am_sourceID_t sourceID);
     am_Error_e changeSourceAvailabilityDB(const am_Availability_s &availability, const am_sourceID_t sourceID);
     am_Error_e changeSystemPropertyDB(const am_SystemProperty_s &property);
     am_Error_e removeMainConnectionDB(const am_mainConnectionID_t mainConnectionID);

--- a/AudioManagerCore/include/CAmControlReceiver.h
+++ b/AudioManagerCore/include/CAmControlReceiver.h
@@ -81,6 +81,7 @@ public:
     am_Error_e changeMainSourceSoundPropertiesDB(const std::vector<am_MainSoundProperty_s> &listSoundProperties, const am_sourceID_t sourceID);
     am_Error_e changeSourceAvailabilityDB(const am_Availability_s &availability, const am_sourceID_t sourceID);
     am_Error_e changeSystemPropertyDB(const am_SystemProperty_s &property);
+    am_Error_e changeSystemPropertiesDB(const std::vector<am_SystemProperty_s> &listSystemProperties);
     am_Error_e removeMainConnectionDB(const am_mainConnectionID_t mainConnectionID);
     am_Error_e removeSinkDB(const am_sinkID_t sinkID);
     am_Error_e removeSourceDB(const am_sourceID_t sourceID);

--- a/AudioManagerCore/include/CAmControlSender.h
+++ b/AudioManagerCore/include/CAmControlSender.h
@@ -54,6 +54,7 @@ public:
     am_Error_e hookUserSetMainSourceSoundProperty(const am_sourceID_t sourceID, const am_MainSoundProperty_s &soundProperty);
     am_Error_e hookUserSetMainSourceSoundProperties(const am_sourceID_t sourceID, const std::vector<am_MainSoundProperty_s > &listSoundProperties);
     am_Error_e hookUserSetSystemProperty(const am_SystemProperty_s &property);
+    am_Error_e hookUserSetSystemProperties(const std::vector<am_SystemProperty_s> &listSystemProperties);
     am_Error_e hookUserVolumeChange(const am_sinkID_t SinkID, const am_mainVolume_t newVolume);
     am_Error_e hookUserVolumeStep(const am_sinkID_t SinkID, const int16_t increment);
     am_Error_e hookUserSetSinkMuteState(const am_sinkID_t sinkID, const am_MuteState_e muteState);

--- a/AudioManagerCore/include/CAmControlSender.h
+++ b/AudioManagerCore/include/CAmControlSender.h
@@ -50,7 +50,9 @@ public:
     am_Error_e hookUserConnectionRequest(const am_sourceID_t sourceID, const am_sinkID_t sinkID, am_mainConnectionID_t &mainConnectionID);
     am_Error_e hookUserDisconnectionRequest(const am_mainConnectionID_t connectionID);
     am_Error_e hookUserSetMainSinkSoundProperty(const am_sinkID_t sinkID, const am_MainSoundProperty_s &soundProperty);
+    am_Error_e hookUserSetMainSinkSoundProperties(const am_sinkID_t sinkID, const std::vector<am_MainSoundProperty_s > &listSoundProperties);
     am_Error_e hookUserSetMainSourceSoundProperty(const am_sourceID_t sourceID, const am_MainSoundProperty_s &soundProperty);
+    am_Error_e hookUserSetMainSourceSoundProperties(const am_sourceID_t sourceID, const std::vector<am_MainSoundProperty_s > &listSoundProperties);
     am_Error_e hookUserSetSystemProperty(const am_SystemProperty_s &property);
     am_Error_e hookUserVolumeChange(const am_sinkID_t SinkID, const am_mainVolume_t newVolume);
     am_Error_e hookUserVolumeStep(const am_sinkID_t SinkID, const int16_t increment);

--- a/AudioManagerCore/include/CAmDatabaseHandlerMap.h
+++ b/AudioManagerCore/include/CAmDatabaseHandlerMap.h
@@ -97,7 +97,9 @@ public:
         std::function<void(const am_crossfaderID_t)> dboRemoveCrossfader;
         std::function<void(const am_mainConnectionID_t, const am_ConnectionState_e)> dboMainConnectionStateChanged;
         std::function<void(const am_sinkID_t, const am_MainSoundProperty_s &)> dboMainSinkSoundPropertyChanged;
+        std::function<void(const am_sinkID_t, const std::vector<am_MainSoundProperty_s> &)> dboMainSinkSoundPropertiesChanged;
         std::function<void(const am_sourceID_t, const am_MainSoundProperty_s &)> dboMainSourceSoundPropertyChanged;
+        std::function<void(const am_sourceID_t, const std::vector<am_MainSoundProperty_s> &)> dboMainSourceSoundPropertiesChanged;
         std::function<void(const am_sinkID_t, const am_Availability_s &)> dboSinkAvailabilityChanged;
         std::function<void(const am_sourceID_t, const am_Availability_s &)> dboSourceAvailabilityChanged;
         std::function<void(const am_sinkID_t, const am_mainVolume_t)> dboVolumeChanged;
@@ -137,7 +139,9 @@ public:
     am_Error_e changeDomainStateDB(const am_DomainState_e domainState, const am_domainID_t domainID);
     am_Error_e changeSinkMuteStateDB(const am_MuteState_e muteState, const am_sinkID_t sinkID);
     am_Error_e changeMainSinkSoundPropertyDB(const am_MainSoundProperty_s &soundProperty, const am_sinkID_t sinkID);
+    am_Error_e changeMainSinkSoundPropertiesDB(const std::vector<am_MainSoundProperty_s> &listSoundProperties, const am_sinkID_t sinkID);
     am_Error_e changeMainSourceSoundPropertyDB(const am_MainSoundProperty_s &soundProperty, const am_sourceID_t sourceID);
+    am_Error_e changeMainSourceSoundPropertiesDB(const std::vector<am_MainSoundProperty_s> &listSoundProperties, const am_sourceID_t sourceID);
     am_Error_e changeSourceSoundPropertyDB(const am_SoundProperty_s &soundProperty, const am_sourceID_t sourceID);
     am_Error_e changeSinkSoundPropertyDB(const am_SoundProperty_s &soundProperty, const am_sinkID_t sinkID);
     am_Error_e changeSourceAvailabilityDB(const am_Availability_s &availability, const am_sourceID_t sourceID);

--- a/AudioManagerCore/include/CAmDatabaseHandlerMap.h
+++ b/AudioManagerCore/include/CAmDatabaseHandlerMap.h
@@ -105,6 +105,7 @@ public:
         std::function<void(const am_sinkID_t, const am_mainVolume_t)> dboVolumeChanged;
         std::function<void(const am_sinkID_t, const am_MuteState_e)> dboSinkMuteStateChanged;
         std::function<void(const am_SystemProperty_s &)>dboSystemPropertyChanged;
+        std::function<void(const std::vector<am_SystemProperty_s> &)>dboSystemPropertiesChanged;
         std::function<void(const am_mainConnectionID_t, const am_timeSync_t)>dboTimingInformationChanged;
         std::function<void(const am_sinkID_t, const am_sinkClass_t, const std::vector<am_MainSoundProperty_s> &, const bool)>dboSinkUpdated;
         std::function<void(const am_sourceID_t, const am_sourceClass_t, const std::vector<am_MainSoundProperty_s> &, const bool)>dboSourceUpdated;
@@ -146,6 +147,7 @@ public:
     am_Error_e changeSinkSoundPropertyDB(const am_SoundProperty_s &soundProperty, const am_sinkID_t sinkID);
     am_Error_e changeSourceAvailabilityDB(const am_Availability_s &availability, const am_sourceID_t sourceID);
     am_Error_e changeSystemPropertyDB(const am_SystemProperty_s &property);
+    am_Error_e changeSystemPropertiesDB(const std::vector<am_SystemProperty_s> &listSystemProperties);
     am_Error_e changeDelayMainConnection(const am_timeSync_t &delay, const am_mainConnectionID_t &connectionID);
     am_Error_e changeSinkClassInfoDB(const am_SinkClass_s &sinkClass);
     am_Error_e changeSourceClassInfoDB(const am_SourceClass_s &sourceClass);

--- a/AudioManagerCore/include/IAmDatabaseHandler.h
+++ b/AudioManagerCore/include/IAmDatabaseHandler.h
@@ -86,6 +86,7 @@ public:
     virtual am_Error_e changeSinkSoundPropertyDB(const am_SoundProperty_s &soundProperty, const am_sinkID_t sinkID) = 0;
     virtual am_Error_e changeSourceAvailabilityDB(const am_Availability_s &availability, const am_sourceID_t sourceID) = 0;
     virtual am_Error_e changeSystemPropertyDB(const am_SystemProperty_s &property) = 0;
+    virtual am_Error_e changeSystemPropertiesDB(const std::vector<am_SystemProperty_s> &listSystemProperties) = 0;
     virtual am_Error_e changeDelayMainConnection(const am_timeSync_t &delay, const am_mainConnectionID_t &connectionID) = 0;
     virtual am_Error_e changeSinkClassInfoDB(const am_SinkClass_s &sinkClass) = 0;
     virtual am_Error_e changeSourceClassInfoDB(const am_SourceClass_s &sourceClass) = 0;

--- a/AudioManagerCore/include/IAmDatabaseHandler.h
+++ b/AudioManagerCore/include/IAmDatabaseHandler.h
@@ -79,7 +79,9 @@ public:
     virtual am_Error_e changeDomainStateDB(const am_DomainState_e domainState, const am_domainID_t domainID) = 0;
     virtual am_Error_e changeSinkMuteStateDB(const am_MuteState_e muteState, const am_sinkID_t sinkID) = 0;
     virtual am_Error_e changeMainSinkSoundPropertyDB(const am_MainSoundProperty_s &soundProperty, const am_sinkID_t sinkID) = 0;
+    virtual am_Error_e changeMainSinkSoundPropertiesDB(const std::vector<am_MainSoundProperty_s> &listSoundProperties, const am_sinkID_t sinkID) = 0;
     virtual am_Error_e changeMainSourceSoundPropertyDB(const am_MainSoundProperty_s &soundProperty, const am_sourceID_t sourceID) = 0;
+    virtual am_Error_e changeMainSourceSoundPropertiesDB(const std::vector<am_MainSoundProperty_s> &listSoundProperties, const am_sourceID_t sourceID) = 0;
     virtual am_Error_e changeSourceSoundPropertyDB(const am_SoundProperty_s &soundProperty, const am_sourceID_t sourceID) = 0;
     virtual am_Error_e changeSinkSoundPropertyDB(const am_SoundProperty_s &soundProperty, const am_sinkID_t sinkID) = 0;
     virtual am_Error_e changeSourceAvailabilityDB(const am_Availability_s &availability, const am_sourceID_t sourceID) = 0;

--- a/AudioManagerCore/src/CAmCommandReceiver.cpp
+++ b/AudioManagerCore/src/CAmCommandReceiver.cpp
@@ -135,6 +135,11 @@ am_Error_e CAmCommandReceiver::setSystemProperty(const am_SystemProperty_s &prop
     return (mControlSender->hookUserSetSystemProperty(property));
 }
 
+am_Error_e CAmCommandReceiver::setSystemProperties(const std::vector<am_SystemProperty_s> &listSystemProperties)
+{
+    return (mControlSender->hookUserSetSystemProperties(listSystemProperties));
+}
+
 am_Error_e CAmCommandReceiver::getVolume(const am_sinkID_t sinkID, am_mainVolume_t &mainVolume) const
 {
     return (mDatabaseHandler->getSinkMainVolume(sinkID, mainVolume));

--- a/AudioManagerCore/src/CAmCommandReceiver.cpp
+++ b/AudioManagerCore/src/CAmCommandReceiver.cpp
@@ -111,10 +111,22 @@ am_Error_e CAmCommandReceiver::setMainSinkSoundProperty(const am_MainSoundProper
     return (mControlSender->hookUserSetMainSinkSoundProperty(sinkID, soundProperty));
 }
 
+am_Error_e CAmCommandReceiver::setMainSinkSoundProperties(const std::vector<am_MainSoundProperty_s> &listSoundProperties, const am_sinkID_t sinkID)
+{
+    logInfo(__METHOD_NAME__, "sinkID=", sinkID);
+    return (mControlSender->hookUserSetMainSinkSoundProperties(sinkID, listSoundProperties));
+}
+
 am_Error_e CAmCommandReceiver::setMainSourceSoundProperty(const am_MainSoundProperty_s &soundProperty, const am_sourceID_t sourceID)
 {
     logInfo(__METHOD_NAME__, "sourceID=", sourceID, "soundPropertyType=", soundProperty.type, "soundPropertyValue=", soundProperty.value);
     return (mControlSender->hookUserSetMainSourceSoundProperty(sourceID, soundProperty));
+}
+
+am_Error_e CAmCommandReceiver::setMainSourceSoundProperties(const std::vector<am_MainSoundProperty_s> &listSoundProperties, const am_sourceID_t sourceID)
+{
+    logInfo(__METHOD_NAME__, "sourceID=", sourceID);
+    return (mControlSender->hookUserSetMainSourceSoundProperties(sourceID, listSoundProperties));
 }
 
 am_Error_e CAmCommandReceiver::setSystemProperty(const am_SystemProperty_s &property)

--- a/AudioManagerCore/src/CAmCommandSender.cpp
+++ b/AudioManagerCore/src/CAmCommandSender.cpp
@@ -118,8 +118,14 @@ CAmCommandSender::CAmCommandSender(const std::vector<std::string> &listOfPluginD
     dboMainSinkSoundPropertyChanged = [&](const am_sinkID_t sinkID, const am_MainSoundProperty_s &SoundProperty) {
             mSerializer.asyncCall(this, &CAmCommandSender::cbMainSinkSoundPropertyChanged, sinkID, SoundProperty);
         };
+    dboMainSinkSoundPropertiesChanged = [&](const am_sinkID_t sinkID, const std::vector<am_MainSoundProperty_s> &listSoundProperties) {
+            mSerializer.asyncCall(this, &CAmCommandSender::cbMainSinkSoundPropertiesChanged, sinkID, listSoundProperties);
+        };
     dboMainSourceSoundPropertyChanged = [&](const am_sourceID_t sourceID, const am_MainSoundProperty_s &SoundProperty) {
             mSerializer.asyncCall(this, &CAmCommandSender::cbMainSourceSoundPropertyChanged, sourceID, SoundProperty);
+        };
+    dboMainSourceSoundPropertiesChanged = [&](const am_sourceID_t sourceID, const std::vector<am_MainSoundProperty_s> &listSoundProperties) {
+            mSerializer.asyncCall(this, &CAmCommandSender::cbMainSourceSoundPropertiesChanged, sourceID, listSoundProperties);
         };
     dboSinkAvailabilityChanged = [&](const am_sinkID_t sinkID, const am_Availability_s &availability) {
             mSerializer.asyncCall(this, &CAmCommandSender::cbSinkAvailabilityChanged, sinkID, availability);
@@ -310,9 +316,19 @@ void CAmCommandSender::cbMainSinkSoundPropertyChanged(const am_sinkID_t sinkID, 
     CALL_ALL_INTERFACES(cbMainSinkSoundPropertyChanged(sinkID, SoundProperty))
 }
 
+void CAmCommandSender::cbMainSinkSoundPropertiesChanged(const am_sinkID_t sinkID, const std::vector<am_MainSoundProperty_s> &listSoundProperties)
+{
+    CALL_ALL_INTERFACES(cbMainSinkSoundPropertiesChanged(sinkID, listSoundProperties))
+}
+
 void CAmCommandSender::cbMainSourceSoundPropertyChanged(const am_sourceID_t sourceID, const am_MainSoundProperty_s &SoundProperty)
 {
     CALL_ALL_INTERFACES(cbMainSourceSoundPropertyChanged(sourceID, SoundProperty))
+}
+
+void CAmCommandSender::cbMainSourceSoundPropertiesChanged(const am_sourceID_t sourceID, const std::vector<am_MainSoundProperty_s> &listSoundProperties)
+{
+    CALL_ALL_INTERFACES(cbMainSourceSoundPropertiesChanged(sourceID, listSoundProperties))
 }
 
 void CAmCommandSender::cbSinkAvailabilityChanged(const am_sinkID_t sinkID, const am_Availability_s &availability)

--- a/AudioManagerCore/src/CAmCommandSender.cpp
+++ b/AudioManagerCore/src/CAmCommandSender.cpp
@@ -142,6 +142,9 @@ CAmCommandSender::CAmCommandSender(const std::vector<std::string> &listOfPluginD
     dboSystemPropertyChanged = [&](const am_SystemProperty_s &SystemProperty) {
             mSerializer.asyncCall(this, &CAmCommandSender::cbSystemPropertyChanged, SystemProperty);
         };
+    dboSystemPropertiesChanged = [&](const std::vector<am_SystemProperty_s> &SystemProperties) {
+            mSerializer.asyncCall(this, &CAmCommandSender::cbSystemPropertiesChanged, SystemProperties);
+        };
     dboTimingInformationChanged = [&](const am_mainConnectionID_t mainConnection, const am_timeSync_t time) {
             mSerializer.asyncCall(this, &CAmCommandSender::cbTimingInformationChanged, mainConnection, time);
         };
@@ -354,6 +357,11 @@ void CAmCommandSender::cbSinkMuteStateChanged(const am_sinkID_t sinkID, const am
 void CAmCommandSender::cbSystemPropertyChanged(const am_SystemProperty_s &SystemProperty)
 {
     CALL_ALL_INTERFACES(cbSystemPropertyChanged(SystemProperty))
+}
+
+void CAmCommandSender::cbSystemPropertiesChanged(const std::vector<am_SystemProperty_s> &listSystemProperties)
+{
+    CALL_ALL_INTERFACES(cbSystemPropertiesChanged(listSystemProperties))
 }
 
 void CAmCommandSender::cbTimingInformationChanged(const am_mainConnectionID_t mainConnection, const am_timeSync_t time)

--- a/AudioManagerCore/src/CAmControlReceiver.cpp
+++ b/AudioManagerCore/src/CAmControlReceiver.cpp
@@ -231,6 +231,11 @@ am_Error_e CAmControlReceiver::changeSystemPropertyDB(const am_SystemProperty_s 
     return (mDatabaseHandler->changeSystemPropertyDB(property));
 }
 
+am_Error_e CAmControlReceiver::changeSystemPropertiesDB(const std::vector<am_SystemProperty_s> &listSystemProperties)
+{
+    return (mDatabaseHandler->changeSystemPropertiesDB(listSystemProperties));
+}
+
 am_Error_e CAmControlReceiver::removeMainConnectionDB(const am_mainConnectionID_t mainConnectionID)
 {
     return (mDatabaseHandler->removeMainConnectionDB(mainConnectionID));

--- a/AudioManagerCore/src/CAmControlReceiver.cpp
+++ b/AudioManagerCore/src/CAmControlReceiver.cpp
@@ -206,9 +206,19 @@ am_Error_e CAmControlReceiver::changeMainSinkSoundPropertyDB(const am_MainSoundP
     return (mDatabaseHandler->changeMainSinkSoundPropertyDB(soundProperty, sinkID));
 }
 
+am_Error_e CAmControlReceiver::changeMainSinkSoundPropertiesDB(const std::vector<am_MainSoundProperty_s> &listSoundProperties, const am_sinkID_t sinkID)
+{
+    return (mDatabaseHandler->changeMainSinkSoundPropertiesDB(listSoundProperties, sinkID));
+}
+
 am_Error_e CAmControlReceiver::changeMainSourceSoundPropertyDB(const am_MainSoundProperty_s &soundProperty, const am_sourceID_t sourceID)
 {
     return (mDatabaseHandler->changeMainSourceSoundPropertyDB(soundProperty, sourceID));
+}
+
+am_Error_e CAmControlReceiver::changeMainSourceSoundPropertiesDB(const std::vector<am_MainSoundProperty_s> &listSoundProperties, const am_sourceID_t sourceID)
+{
+    return (mDatabaseHandler->changeMainSourceSoundPropertiesDB(listSoundProperties, sourceID));
 }
 
 am_Error_e CAmControlReceiver::changeSourceAvailabilityDB(const am_Availability_s &availability, const am_sourceID_t sourceID)

--- a/AudioManagerCore/src/CAmControlSender.cpp
+++ b/AudioManagerCore/src/CAmControlSender.cpp
@@ -217,6 +217,12 @@ am_Error_e CAmControlSender::hookUserSetSystemProperty(const am_SystemProperty_s
     return (mController->hookUserSetSystemProperty(property));
 }
 
+am_Error_e CAmControlSender::hookUserSetSystemProperties(const std::vector<am_SystemProperty_s> &listSystemProperties)
+{
+    assert(mController);
+    return (mController->hookUserSetSystemProperties(listSystemProperties));
+}
+
 am_Error_e CAmControlSender::hookUserVolumeChange(const am_sinkID_t sinkID, const am_mainVolume_t newVolume)
 {
     assert(mController);

--- a/AudioManagerCore/src/CAmControlSender.cpp
+++ b/AudioManagerCore/src/CAmControlSender.cpp
@@ -193,10 +193,22 @@ am_Error_e CAmControlSender::hookUserSetMainSinkSoundProperty(const am_sinkID_t 
     return (mController->hookUserSetMainSinkSoundProperty(sinkID, soundProperty));
 }
 
+am_Error_e CAmControlSender::hookUserSetMainSinkSoundProperties(const am_sinkID_t sinkID, const std::vector<am_MainSoundProperty_s > &listSoundProperties)
+{
+    assert(mController);
+    return (mController->hookUserSetMainSinkSoundProperties(sinkID, listSoundProperties));
+}
+
 am_Error_e CAmControlSender::hookUserSetMainSourceSoundProperty(const am_sourceID_t sourceID, const am_MainSoundProperty_s &soundProperty)
 {
     assert(mController);
     return (mController->hookUserSetMainSourceSoundProperty(sourceID, soundProperty));
+}
+
+am_Error_e CAmControlSender::hookUserSetMainSourceSoundProperties(const am_sourceID_t sourceID, const std::vector<am_MainSoundProperty_s > &listSoundProperties)
+{
+    assert(mController);
+    return (mController->hookUserSetMainSourceSoundProperties(sourceID, listSoundProperties));
 }
 
 am_Error_e CAmControlSender::hookUserSetSystemProperty(const am_SystemProperty_s &property)

--- a/AudioManagerCore/src/CAmDatabaseHandlerMap.cpp
+++ b/AudioManagerCore/src/CAmDatabaseHandlerMap.cpp
@@ -1689,6 +1689,32 @@ am_Error_e CAmDatabaseHandlerMap::changeSystemPropertyDB(const am_SystemProperty
     }
 }
 
+am_Error_e CAmDatabaseHandlerMap::changeSystemPropertiesDB(const std::vector<am_SystemProperty_s> &listSystemProperties)
+{
+    std::vector<am_SystemProperty_s>::iterator elementIterator;
+
+    for (auto &itlistSystemProperties : listSystemProperties)
+    {
+        for (elementIterator = mMappedData.mSystemProperties.begin(); elementIterator != mMappedData.mSystemProperties.end();
+                ++elementIterator)
+        {
+            if (elementIterator->type == itlistSystemProperties.type)
+            {
+                DB_COND_UPDATE_RIE(elementIterator->value, itlistSystemProperties.value);
+            }
+            else
+                logVerbose("DatabaseHandler::changeSystemPropertiesDB system property does not match the internal list");
+        }
+
+    }
+
+    logVerbose("DatabaseHandler::changeSystemPropertiesDB changed system property");
+
+    NOTIFY_OBSERVERS1(dboSystemPropertiesChanged, listSystemProperties)
+
+    return (E_OK);
+}
+
 am_Error_e CAmDatabaseHandlerMap::removeMainConnectionDB(const am_mainConnectionID_t mainConnectionID)
 {
 

--- a/AudioManagerCore/src/CAmDatabaseHandlerMap.cpp
+++ b/AudioManagerCore/src/CAmDatabaseHandlerMap.cpp
@@ -1526,6 +1526,42 @@ am_Error_e CAmDatabaseHandlerMap::changeMainSinkSoundPropertyDB(const am_MainSou
     }
 }
 
+am_Error_e CAmDatabaseHandlerMap::changeMainSinkSoundPropertiesDB(const std::vector<am_MainSoundProperty_s> &listSoundProperties, const am_sinkID_t sinkID)
+{
+
+    if (!existSink(sinkID))
+    {
+        logError(__METHOD_NAME__, "sinkID=", sinkID," must exist");
+        return (E_NON_EXISTENT);
+    }
+
+    am_Sink_Database_s                           &sink = mMappedData.mSinkMap[sinkID];
+    std::vector<am_MainSoundProperty_s>::iterator elementIterator;
+
+    for (auto &itlistSoundProperties : listSoundProperties )
+    {
+        for (elementIterator = sink.listMainSoundProperties.begin(); elementIterator != sink.listMainSoundProperties.end();
+             ++elementIterator )
+        {
+            if (elementIterator->type == itlistSoundProperties.type)
+            {
+                DB_COND_UPDATE_RIE(elementIterator->value, itlistSoundProperties.value);
+                if (sink.cacheMainSoundProperties.size())
+                {
+                    sink.cacheMainSoundProperties[itlistSoundProperties.type] = itlistSoundProperties.value;
+                }
+
+                break;
+            }
+        }
+    }
+
+    logVerbose("DatabaseHandler::changeMainSinkSoundPropertiesDB changed MainSinkSoundProperties of sink:", sinkID);
+
+    NOTIFY_OBSERVERS2(dboMainSinkSoundPropertiesChanged, sinkID, listSoundProperties)
+    return (E_OK);
+}
+
 am_Error_e CAmDatabaseHandlerMap::changeMainSourceSoundPropertyDB(const am_MainSoundProperty_s &soundProperty, const am_sourceID_t sourceID)
 {
 
@@ -1565,6 +1601,41 @@ am_Error_e CAmDatabaseHandlerMap::changeMainSourceSoundPropertyDB(const am_MainS
         logVerbose("DatabaseHandler::changeMainSourceSoundPropertyDB called MainSinkSoundProperty of source:", sourceID, "type:", soundProperty.type, "to:", soundProperty.value);
         return (E_NO_CHANGE);
     }
+}
+
+am_Error_e CAmDatabaseHandlerMap::changeMainSourceSoundPropertiesDB(const std::vector<am_MainSoundProperty_s> &listSoundProperties, const am_sourceID_t sourceID)
+{
+    if (!existSource(sourceID))
+    {
+        logError(__METHOD_NAME__, "sourceID=", sourceID, " must exist");
+        return (E_NON_EXISTENT);
+    }
+
+    am_Source_Database_s                         &source = mMappedData.mSourceMap.at(sourceID);
+    std::vector<am_MainSoundProperty_s>::iterator elementIterator;
+
+    for (auto &itlistSoundProperties : listSoundProperties )
+    {
+        for (elementIterator = source.listMainSoundProperties.begin(); elementIterator != source.listMainSoundProperties.end();
+             ++elementIterator )
+        {
+            if (elementIterator->type == itlistSoundProperties.type)
+            {
+                DB_COND_UPDATE_RIE(elementIterator->value, itlistSoundProperties.value);
+                if (source.cacheMainSoundProperties.size())
+                {
+                    source.cacheMainSoundProperties[itlistSoundProperties.type] = itlistSoundProperties.value;
+                }
+
+                break;
+            }
+        }
+    }
+
+    logVerbose("DatabaseHandler::changeMainSourceSoundPropertiesDB changed MainSinkSoundProperties of source:", sourceID);
+
+    NOTIFY_OBSERVERS2(dboMainSourceSoundPropertiesChanged, sourceID, listSoundProperties)
+    return (E_OK);
 }
 
 am_Error_e CAmDatabaseHandlerMap::changeSourceAvailabilityDB(const am_Availability_s &availability, const am_sourceID_t sourceID)

--- a/AudioManagerCore/test/AmMapHandlerTest/CAmTestDatabaseObserver.cpp
+++ b/AudioManagerCore/test/AmMapHandlerTest/CAmTestDatabaseObserver.cpp
@@ -80,6 +80,8 @@ CAmDatabaseObserver::CAmDatabaseObserver()
 		{ MockDatabaseObserver::getMockObserverObject()->sinkMuteStateChanged(sinkID, muteState); };
 		dboSystemPropertyChanged = [&](const am_SystemProperty_s& SystemProperty)
 		{ MockDatabaseObserver::getMockObserverObject()->systemPropertyChanged(SystemProperty); };
+		dboSystemPropertiesChanged = [&](const std::vector<am_SystemProperty_s>& listSystemProperties)
+		{ MockDatabaseObserver::getMockObserverObject()->systemPropertiesChanged(listSystemProperties); };
 		dboTimingInformationChanged = [&](const am_mainConnectionID_t mainConnection, const am_timeSync_t time)
 		{ MockDatabaseObserver::getMockObserverObject()->timingInformationChanged(mainConnection,time); };
 		dboSinkUpdated = [&](const am_sinkID_t sinkID, const am_sinkClass_t sinkClassID, const std::vector<am_MainSoundProperty_s>& listMainSoundProperties, const bool visible)

--- a/AudioManagerCore/test/AmMapHandlerTest/CAmTestDatabaseObserver.cpp
+++ b/AudioManagerCore/test/AmMapHandlerTest/CAmTestDatabaseObserver.cpp
@@ -64,8 +64,12 @@ CAmDatabaseObserver::CAmDatabaseObserver()
 		{ MockDatabaseObserver::getMockObserverObject()->mainConnectionStateChanged(connectionID, connectionState); };
 		dboMainSinkSoundPropertyChanged = [&](const am_sinkID_t sinkID, const am_MainSoundProperty_s& SoundProperty)
 		{ MockDatabaseObserver::getMockObserverObject()->mainSinkSoundPropertyChanged(sinkID, SoundProperty); };
+		dboMainSinkSoundPropertiesChanged = [&](const am_sinkID_t sinkID, const std::vector<am_MainSoundProperty_s>& listSoundProperties)
+		{ MockDatabaseObserver::getMockObserverObject()->mainSinkSoundPropertiesChanged(sinkID, listSoundProperties); };
 		dboMainSourceSoundPropertyChanged = [&](const am_sourceID_t sourceID, const am_MainSoundProperty_s& SoundProperty)
 		{ MockDatabaseObserver::getMockObserverObject()->mainSourceSoundPropertyChanged(sourceID, SoundProperty); };
+		dboMainSourceSoundPropertiesChanged = [&](const am_sourceID_t sourceID, const std::vector<am_MainSoundProperty_s>& listSoundProperties)
+		{ MockDatabaseObserver::getMockObserverObject()->mainSourceSoundPropertiesChanged(sourceID, listSoundProperties); };
 		dboSinkAvailabilityChanged = [&](const am_sinkID_t sinkID, const am_Availability_s& availability)
 		{ MockDatabaseObserver::getMockObserverObject()->sinkAvailabilityChanged(sinkID, availability); };
 		dboSourceAvailabilityChanged = [&](const am_sourceID_t sourceID, const am_Availability_s& availability)

--- a/AudioManagerCore/test/AmMapHandlerTest/MockDatabaseObserver.h
+++ b/AudioManagerCore/test/AmMapHandlerTest/MockDatabaseObserver.h
@@ -69,6 +69,7 @@ public:
     virtual void volumeChanged(const am_sinkID_t sinkID, const am_mainVolume_t volume) = 0;
     virtual void sinkMuteStateChanged(const am_sinkID_t sinkID, const am_MuteState_e muteState) = 0;
     virtual void systemPropertyChanged(const am_SystemProperty_s& SystemProperty) = 0;
+    virtual void systemPropertiesChanged(const std::vector<am_SystemProperty_s>& listSystemProperties) = 0;
     virtual void timingInformationChanged(const am_mainConnectionID_t mainConnection, const am_timeSync_t time) = 0;
     virtual void sinkUpdated(const am_sinkID_t sinkID, const am_sinkClass_t sinkClassID, const std::vector<am_MainSoundProperty_s>& listMainSoundProperties, const bool visible) = 0;
     virtual void sourceUpdated(const am_sourceID_t sourceID, const am_sourceClass_t sourceClassID, const std::vector<am_MainSoundProperty_s>& listMainSoundProperties, const bool visible) = 0;
@@ -105,6 +106,7 @@ class MockDatabaseObserver : public IAmDatabaseObserver{
 	MOCK_METHOD2(volumeChanged, void(const am_sinkID_t sinkID, const am_mainVolume_t volume));
 	MOCK_METHOD2(sinkMuteStateChanged, void(const am_sinkID_t sinkID, const am_MuteState_e muteState));
 	MOCK_METHOD1(systemPropertyChanged, void(const am_SystemProperty_s& SystemProperty));
+	MOCK_METHOD1(systemPropertiesChanged, void(const std::vector<am_SystemProperty_s>& listSystemProperties));
 	MOCK_METHOD2(timingInformationChanged, void(const am_mainConnectionID_t mainConnection, const am_timeSync_t time));
 	MOCK_METHOD4(sinkUpdated, void(const am_sinkID_t sinkID, const am_sinkClass_t sinkClassID, const std::vector<am_MainSoundProperty_s>& listMainSoundProperties, const bool visible));
 	MOCK_METHOD4(sourceUpdated, void(const am_sourceID_t sourceID, const am_sourceClass_t sourceClassID, const std::vector<am_MainSoundProperty_s>& listMainSoundProperties, const bool visible));

--- a/AudioManagerCore/test/AmMapHandlerTest/MockDatabaseObserver.h
+++ b/AudioManagerCore/test/AmMapHandlerTest/MockDatabaseObserver.h
@@ -61,7 +61,9 @@ public:
     virtual void removeCrossfader(const am_crossfaderID_t crossfaderID) = 0;
     virtual void mainConnectionStateChanged(const am_mainConnectionID_t connectionID, const am_ConnectionState_e connectionState) = 0;
     virtual void mainSinkSoundPropertyChanged(const am_sinkID_t sinkID, const am_MainSoundProperty_s& SoundProperty) = 0;
+    virtual void mainSinkSoundPropertiesChanged(const am_sinkID_t sinkID, const std::vector<am_MainSoundProperty_s>& listSoundProperties) = 0;
     virtual void mainSourceSoundPropertyChanged(const am_sourceID_t sourceID, const am_MainSoundProperty_s& SoundProperty) = 0;
+    virtual void mainSourceSoundPropertiesChanged(const am_sourceID_t sourceID, const std::vector<am_MainSoundProperty_s>& listSoundProperties) = 0;
     virtual void sinkAvailabilityChanged(const am_sinkID_t sinkID, const am_Availability_s& availability) = 0;
     virtual void sourceAvailabilityChanged(const am_sourceID_t sourceID, const am_Availability_s& availability) = 0;
     virtual void volumeChanged(const am_sinkID_t sinkID, const am_mainVolume_t volume) = 0;
@@ -95,7 +97,9 @@ class MockDatabaseObserver : public IAmDatabaseObserver{
 	MOCK_METHOD1(removeCrossfader, void(const am_crossfaderID_t crossfaderID));
 	MOCK_METHOD2(mainConnectionStateChanged, void(const am_mainConnectionID_t connectionID, const am_ConnectionState_e connectionState));
 	MOCK_METHOD2(mainSinkSoundPropertyChanged, void(const am_sinkID_t sinkID, const am_MainSoundProperty_s& SoundProperty));
+	MOCK_METHOD2(mainSinkSoundPropertiesChanged, void(const am_sinkID_t sinkID, const std::vector<am_MainSoundProperty_s>& listSoundProperties));
 	MOCK_METHOD2(mainSourceSoundPropertyChanged, void(const am_sourceID_t sourceID, const am_MainSoundProperty_s& SoundProperty));
+	MOCK_METHOD2(mainSourceSoundPropertiesChanged, void(const am_sourceID_t sourceID, const std::vector<am_MainSoundProperty_s>& listSoundProperties));
 	MOCK_METHOD2(sinkAvailabilityChanged, void(const am_sinkID_t sinkID, const am_Availability_s& availability));
 	MOCK_METHOD2(sourceAvailabilityChanged, void(const am_sourceID_t sourceID, const am_Availability_s& availability));
 	MOCK_METHOD2(volumeChanged, void(const am_sinkID_t sinkID, const am_mainVolume_t volume));

--- a/AudioManagerCore/test/MockIAmCommandSend.h
+++ b/AudioManagerCore/test/MockIAmCommandSend.h
@@ -59,8 +59,12 @@ class MockIAmCommandSend : public IAmCommandSend {
         void(const am_mainConnectionID_t connectionID, const am_ConnectionState_e connectionState));
     MOCK_METHOD2(cbMainSinkSoundPropertyChanged,
         void(const am_sinkID_t sinkID, const am_MainSoundProperty_s& soundProperty));
+    MOCK_METHOD2(cbMainSinkSoundPropertiesChanged,
+        void(const am_sinkID_t sinkID, const std::vector<am_MainSoundProperty_s>& listSoundProperties));
     MOCK_METHOD2(cbMainSourceSoundPropertyChanged,
         void(const am_sourceID_t sourceID, const am_MainSoundProperty_s& soundProperty));
+    MOCK_METHOD2(cbMainSourceSoundPropertiesChanged,
+        void(const am_sourceID_t sourcekID, const std::vector<am_MainSoundProperty_s>& listSoundProperties));
     MOCK_METHOD2(cbSinkAvailabilityChanged,
         void(const am_sinkID_t sinkID, const am_Availability_s& availability));
     MOCK_METHOD2(cbSourceAvailabilityChanged,

--- a/AudioManagerCore/test/MockIAmCommandSend.h
+++ b/AudioManagerCore/test/MockIAmCommandSend.h
@@ -75,6 +75,8 @@ class MockIAmCommandSend : public IAmCommandSend {
         void(const am_sinkID_t sinkID, const am_MuteState_e muteState));
     MOCK_METHOD1(cbSystemPropertyChanged,
         void(const am_SystemProperty_s& systemProperty));
+    MOCK_METHOD1(cbSystemPropertiesChanged,
+        void(const std::vector<am_SystemProperty_s>& listSystemProperties));
     MOCK_METHOD2(cbTimingInformationChanged,
         void(const am_mainConnectionID_t mainConnectionID, const am_timeSync_t time));
     MOCK_METHOD3(cbSinkUpdated,

--- a/AudioManagerCore/test/MockIAmControlSend.h
+++ b/AudioManagerCore/test/MockIAmControlSend.h
@@ -45,8 +45,12 @@ class MockIAmControlSend : public IAmControlSend {
       am_Error_e(const am_mainConnectionID_t connectionID));
   MOCK_METHOD2(hookUserSetMainSinkSoundProperty,
       am_Error_e(const am_sinkID_t sinkID, const am_MainSoundProperty_s& soundProperty));
+  MOCK_METHOD2(hookUserSetMainSinkSoundProperties,
+      am_Error_e(const am_sinkID_t sinkID, const std::vector<am_MainSoundProperty_s > &listSoundProperty));
   MOCK_METHOD2(hookUserSetMainSourceSoundProperty,
       am_Error_e(const am_sourceID_t sourceID, const am_MainSoundProperty_s& soundProperty));
+  MOCK_METHOD2(hookUserSetMainSourceSoundProperties,
+      am_Error_e(const am_sourceID_t sourceID, const std::vector<am_MainSoundProperty_s > &listSoundProperty));
   MOCK_METHOD1(hookUserSetSystemProperty,
       am_Error_e(const am_SystemProperty_s& property));
   MOCK_METHOD2(hookUserVolumeChange,

--- a/AudioManagerCore/test/MockIAmControlSend.h
+++ b/AudioManagerCore/test/MockIAmControlSend.h
@@ -53,6 +53,8 @@ class MockIAmControlSend : public IAmControlSend {
       am_Error_e(const am_sourceID_t sourceID, const std::vector<am_MainSoundProperty_s > &listSoundProperty));
   MOCK_METHOD1(hookUserSetSystemProperty,
       am_Error_e(const am_SystemProperty_s& property));
+  MOCK_METHOD1(hookUserSetSystemProperties,
+      am_Error_e(const std::vector<am_SystemProperty_s>& listSystemProperties));
   MOCK_METHOD2(hookUserVolumeChange,
       am_Error_e(const am_sinkID_t SinkID, const am_mainVolume_t newVolume));
   MOCK_METHOD2(hookUserVolumeStep,

--- a/include/IAmCommand.h
+++ b/include/IAmCommand.h
@@ -34,7 +34,7 @@ class CAmSocketHandler;
 
 #include "audiomanagertypes.h"
 
-#define CommandVersion "4.0" 
+#define CommandVersion "4.1" 
 namespace am {
 
 /**
@@ -108,6 +108,12 @@ public:
 	 */
 	virtual am_Error_e setMainSinkSoundProperty(const am_MainSoundProperty_s& soundProperty, const am_sinkID_t sinkID) =0;
 	/**
+	 * This method is used to set the list of sound properties
+	 * @return E_OK on success, E_OUT_OF_RANGE if value exceeds range, E_UNKNOWN in
+	 * case of an error
+	 */
+	virtual am_Error_e setMainSinkSoundProperties(const std::vector<am_MainSoundProperty_s> &/*listSoundProperties*/, const am_sinkID_t /*sinkID*/) { return E_OK; };
+	/**
 	 * This method is used to set sound properties, e.g. Equalizer Values. Since the
 	 * capabilities of the system can differ, the exact key value pairs can be
 	 * extended in each product
@@ -115,6 +121,12 @@ public:
 	 * case of an error
 	 */
 	virtual am_Error_e setMainSourceSoundProperty(const am_MainSoundProperty_s& soundProperty, const am_sourceID_t sourceID) =0;
+	/**
+	 * This method is used to set the list of sound properties
+	 * @return E_OK on success, E_OUT_OF_RANGE if value exceeds range, E_UNKNOWN in
+	 * case of an error
+	 */
+	virtual am_Error_e setMainSourceSoundProperties(const std::vector<am_MainSoundProperty_s> &/*listSoundProperties*/, const am_sourceID_t /*sourceID*/) { return E_OK; };
 	/**
 	 * is used to set a specific system property.
 	 * @return E_OK on success, E_OUT_OF_RANGE if value exceeds range, E_UNKNOWN in
@@ -322,9 +334,17 @@ public:
 	 */
 	virtual void cbMainSinkSoundPropertyChanged(const am_sinkID_t sinkID, const am_MainSoundProperty_s& soundProperty) =0;
 	/**
+	 * this callback indicates that sourceSoundProperties have changed.
+	 */
+	virtual void cbMainSinkSoundPropertiesChanged(const am_sinkID_t /*sinkID*/, const std::vector<am_MainSoundProperty_s> &/*listSoundProperties*/) { return; };
+	/**
 	 * this callback indicates that a sourceSoundProperty has changed.
 	 */
 	virtual void cbMainSourceSoundPropertyChanged(const am_sourceID_t sourceID, const am_MainSoundProperty_s& soundProperty) =0;
+	/**
+	 * this callback indicates that sourceSoundProperties have changed.
+	 */
+	virtual void cbMainSourceSoundPropertiesChanged(const am_sourceID_t /*sourceID*/, const std::vector<am_MainSoundProperty_s> &/*listSoundProperties*/) { return; };
 	/**
 	 * this callback is called when the availability of a sink has changed
 	 */

--- a/include/IAmCommand.h
+++ b/include/IAmCommand.h
@@ -25,7 +25,6 @@
 
 #include <vector>
 #include <string>
-#include "audiomanagertypes.h"
 namespace am {
 class CAmDbusWrapper;
 class CAmSocketHandler;
@@ -133,6 +132,12 @@ public:
 	 * case of an error
 	 */
 	virtual am_Error_e setSystemProperty(const am_SystemProperty_s& property) =0;
+	/**
+	 * is used to set a specific system properties.
+	 * @return E_OK on success, E_OUT_OF_RANGE if value exceeds range, E_UNKNOWN in
+	 * case of an error
+	 */
+	virtual am_Error_e setSystemProperties(const std::vector<am_SystemProperty_s>&/*listSystemProperties*/ ) { return E_OK; };
 	/**
 	 * returns the actual list of MainConnections
 	 * @return E_OK on success, E_DATABASE_ERROR on error 
@@ -365,6 +370,10 @@ public:
 	 * is fired if a systemProperty changed
 	 */
 	virtual void cbSystemPropertyChanged(const am_SystemProperty_s& systemProperty) =0;
+	/**
+	 * is fired if a systemProperties changed
+	 */
+	virtual void cbSystemPropertiesChanged(const std::vector<am_SystemProperty_s>&/*listSystemProperties*/) { return; };
 	/**
 	 * This callback is fired if the timinginformation for a mainConnectionID changed
 	 */

--- a/include/IAmControl.h
+++ b/include/IAmControl.h
@@ -32,7 +32,7 @@ class CAmSocketHandler;
 
 #include "audiomanagertypes.h"
 
-#define ControlVersion "5.1"
+#define ControlVersion "5.2"
 namespace am {
 
 /**
@@ -302,11 +302,23 @@ public:
 	 */
 	virtual am_Error_e changeMainSinkSoundPropertyDB(const am_MainSoundProperty_s& soundProperty, const am_sinkID_t sinkID) =0;
 	/**
+	 * changes the mainsinksoundproperties of a sink
+	 * @return E_OK on success, E_DATABASE_ERROR on error, E_NON_EXISTENT if sink was
+	 * not found
+	 */
+	virtual am_Error_e changeMainSinkSoundPropertiesDB(const std::vector<am_MainSoundProperty_s>& /*listSoundProperties*/, const am_sinkID_t /*sinkID*/) { return E_OK; };
+	/**
 	 * changes the mainsourcesoundproperty of a sink
 	 * @return E_OK on success, E_DATABASE_ERROR on error, E_NON_EXISTENT if source
 	 * was not found
 	 */
 	virtual am_Error_e changeMainSourceSoundPropertyDB(const am_MainSoundProperty_s& soundProperty, const am_sourceID_t sourceID) =0;
+	/**
+	 * changes the mainsourcesoundproperties of a source
+	 * @return E_OK on success, E_DATABASE_ERROR on error, E_NON_EXISTENT if source
+	 * was not found
+	 */
+	virtual am_Error_e changeMainSourceSoundPropertiesDB(const std::vector<am_MainSoundProperty_s>& /*listSoundProperties*/, const am_sourceID_t /*sourceID*/) { return E_OK; };
 	/**
 	 * changes the availablility of a source
 	 * @return E_OK on success, E_DATABASE_ERROR  on error, E_NON_EXISTENT if source
@@ -726,10 +738,20 @@ public:
 	 */
 	virtual am_Error_e hookUserSetMainSinkSoundProperty(const am_sinkID_t sinkID, const am_MainSoundProperty_s& soundProperty) =0;
 	/**
+	 * sets a user MainSinkSoundProperty list
+	 * @return E_OK on success, E_OUT_OF_RANGE if out of range, E_UNKNOWN on error
+	 */
+	virtual am_Error_e hookUserSetMainSinkSoundProperties(const am_sinkID_t /*sinkID*/, const std::vector<am_MainSoundProperty_s > &/*listSoundProperties*/) { return E_OK;};
+	/**
 	 * sets a user MainSourceSoundProperty
 	 * @return E_OK on success, E_OUT_OF_RANGE if out of range, E_UNKNOWN on error
 	 */
 	virtual am_Error_e hookUserSetMainSourceSoundProperty(const am_sourceID_t sourceID, const am_MainSoundProperty_s& soundProperty) =0;
+	/**
+	 * sets a user MainSourceSoundProperty list
+	 * @return E_OK on success, E_OUT_OF_RANGE if out of range, E_UNKNOWN on error
+	 */
+	virtual am_Error_e hookUserSetMainSourceSoundProperties(const am_sourceID_t /*sourceID*/, const std::vector<am_MainSoundProperty_s > &/*listSoundProperties*/) { return E_OK; };
 	/**
 	 * sets a user SystemProperty
 	 * @return E_OK on success, E_OUT_OF_RANGE if out of range, E_UNKNOWN on error

--- a/include/IAmControl.h
+++ b/include/IAmControl.h
@@ -332,6 +332,12 @@ public:
 	 */
 	virtual am_Error_e changeSystemPropertyDB(const am_SystemProperty_s& property) =0;
 	/**
+	 * changes systemProperties
+	 * @return E_OK on success, E_DATABASE_ERROR on error, E_NON_EXISTENT if property
+	 * was not found
+	 */
+	virtual am_Error_e changeSystemPropertiesDB(const std::vector<am_SystemProperty_s>&/*listSystemProperties*/){ return E_OK; };
+	/**
 	 * removes a mainconnection from the DB
 	 * @return E_OK on success, E_NON_EXISTENT if main connection was not found,
 	 * E_DATABASE_ERROR if the database had an error
@@ -757,6 +763,11 @@ public:
 	 * @return E_OK on success, E_OUT_OF_RANGE if out of range, E_UNKNOWN on error
 	 */
 	virtual am_Error_e hookUserSetSystemProperty(const am_SystemProperty_s& property) =0;
+	/**
+	 * sets a user SystemProperties list
+	 * @return E_OK on success, E_OUT_OF_RANGE if out of range, E_UNKNOWN on error
+	 */
+	virtual am_Error_e hookUserSetSystemProperties(const std::vector<am_SystemProperty_s>& /*listproperties*/){ return E_OK; }
 	/**
 	 * sets a user volume
 	 * @return E_OK on success, E_OUT_OF_RANGE if out of range, E_UNKNOWN on error


### PR DESCRIPTION
This request is about introducing a plural form for the sound property and system property handling. The main purpose of this extension is to allow for one-shot (uninterrupted), consistent change of multiple, possibly interrelated 
-	global configuration attributes (system properties)
-	source or sink sound properties.

To achieve this goal, the public interfaces IAmCommand and IAmControl are extended by new methods, offering the plural form in parallel to the existing singular form. Proper handling is implemented in the AM daemon.
In order to retain backward compatibility the required interfaces IAmCommandSend and IAmControlSend provide empty default implementations for the new methods. 

We (hopefully) discuss this request at:
https://lists.genivi.org/mailman/listinfo/genivi-audio-manager_lists.genivi.org 