### PR TITLE
Build: allow applications and plugins to build against an uninstalled AM

### DIFF
--- a/cmake/AudioManagerConfig.cmake.in
+++ b/cmake/AudioManagerConfig.cmake.in
@@ -1,6 +1,20 @@
 @PACKAGE_INIT@
 
-set_and_check(AudioManager_INCLUDE_DIRS ${PACKAGE_PREFIX_DIR}/include/audiomanager)
+if(AudioManager-uninstalled)
+  # add public AM interface headers
+  set_and_check(AudioManager_INCLUDE_DIRS @CMAKE_SOURCE_DIR@/include)
+
+  # add project-specific AM configuration header
+  find_path(AudioManagerConfig_INCLUDE_DIR 
+                 NAMES audiomanagerconfig.h
+                 PATHS @CMAKE_BINARY_DIR@/include
+                 REQUIRED
+                 )
+  list(APPEND AudioManager_INCLUDE_DIRS ${AudioManagerConfig_INCLUDE_DIR})
+else(AudioManager-uninstalled)
+  # add installed AM interface and configuration headers
+  set_and_check(AudioManager_INCLUDE_DIRS ${PACKAGE_PREFIX_DIR}/include/audiomanager)
+endif(AudioManager-uninstalled)
 
 set(DAEMONVERSION "@DAEMONVERSION@")
 set(TEST_EXECUTABLE_INSTALL_PATH "@TEST_EXECUTABLE_INSTALL_PATH@")
@@ -27,8 +41,4 @@ endif (WITH_SHARED_UTILITIES)
 if (WITH_SHARED_CORE)    
 	check_required_components(AudioManagerCore)
 endif(WITH_SHARED_CORE)
-
-
-
-
 

--- a/cmake/AudioManagerCoreConfig.cmake.in
+++ b/cmake/AudioManagerCoreConfig.cmake.in
@@ -1,7 +1,14 @@
 @PACKAGE_INIT@
 
-set_and_check(AudioManagerCore_INCLUDE_DIRS ${PACKAGE_PREFIX_DIR}/include/@LIB_INSTALL_SUFFIX@/AudioManagerCore)
-find_library(AudioManagerCore_LIBRARIES NAMES AudioManagerCore HINTS ${PACKAGE_PREFIX_DIR}/lib) 
+if(AudioManager-uninstalled)
+  set_and_check(AudioManagerCore_INCLUDE_DIRS @CMAKE_SOURCE_DIR@/AudioManagerCore/include)
+  find_library(AudioManagerCore_LIBRARY NAMES AudioManagerCore
+     PATHS $ENV(AudioManagerCore_LIBRARY) @CMAKE_BINARY_DIR@/AudioManagerCore
+     NO_DEFAULT_PATH) 
+else(AudioManager-uninstalled)
+  set_and_check(AudioManagerCore_INCLUDE_DIRS ${PACKAGE_PREFIX_DIR}/include/@LIB_INSTALL_SUFFIX@/AudioManagerCore)
+  find_library(AudioManagerCore_LIBRARIES NAMES AudioManagerCore HINTS ${PACKAGE_PREFIX_DIR}/lib) 
+endif(AudioManager-uninstalled)
 
 set(DAEMONVERSION "@DAEMONVERSION@")
 set(WITH_SHARED_CORE "@WITH_SHARED_CORE@")

--- a/cmake/AudioManagerUtilitiesConfig.cmake.in
+++ b/cmake/AudioManagerUtilitiesConfig.cmake.in
@@ -1,7 +1,14 @@
 @PACKAGE_INIT@
 
-set_and_check(AudioManagerUtilities_INCLUDE_DIRS ${PACKAGE_PREFIX_DIR}/include/@LIB_INSTALL_SUFFIX@/AudioManagerUtilities)
-find_library(AudioManagerUtilities_LIBRARY NAMES AudioManagerUtilities HINTS ${PACKAGE_PREFIX_DIR}/lib}) 
+if(AudioManager-uninstalled)
+  set_and_check(AudioManagerUtilities_INCLUDE_DIRS @CMAKE_SOURCE_DIR@/AudioManagerUtilities/include)
+  find_library(AudioManagerUtilities_LIBRARY NAMES AudioManagerUtilities
+     PATHS $ENV(AudioManagerUtilities_LIBRARY) @CMAKE_BINARY_DIR@/AudioManagerUtilities
+     NO_DEFAULT_PATH) 
+else(AudioManager-uninstalled)
+  set_and_check(AudioManagerUtilities_INCLUDE_DIRS ${PACKAGE_PREFIX_DIR}/include/@LIB_INSTALL_SUFFIX@/AudioManagerUtilities)
+  find_library(AudioManagerUtilities_LIBRARY NAMES AudioManagerUtilities HINTS ${PACKAGE_PREFIX_DIR}/lib}) 
+endif(AudioManager-uninstalled)
 
 set(WITH_CAPI_WRAPPER "@WITH_CAPI_WRAPPER@")
 set(WITH_DBUS_WRAPPER "@WITH_DBUS_WRAPPER@")


### PR DESCRIPTION
Build: allow applications and plugins to build against an uninstalled AM and its utilities during development phase

    - build AM normally
    - build application or plugin with below cmake options:
        -DAudioManager-uninstalled:OPTION=ON
        -DAudioManager_DIR:PATH=<path-to-AM-build-directory>
        -DAudioManagerUtilities_DIR:PATH=<path-to-AM-build-directory>/AudioManagerUtilities

Signed-off-by: Martin Koch <martin.koch@ese.de>